### PR TITLE
Add getter/setter to the Sinus primitive

### DIFF
--- a/pypot/primitive/utils.py
+++ b/pypot/primitive/utils.py
@@ -1,11 +1,11 @@
 import numpy
 
-import pypot.robot
 import pypot.primitive
 
 
 class Sinus(pypot.primitive.LoopPrimitive):
-    """ Apply a sinus on the motor specified as argument. """
+    """ Apply a sinus on the motor specified as argument. Parameters (amp, offset and phase) should be specified in degree
+    """
     def __init__(self, robot, refresh_freq,
                  motor_list,
                  amp=1, freq=0.5, offset=0, phase=0):
@@ -13,19 +13,57 @@ class Sinus(pypot.primitive.LoopPrimitive):
         pypot.primitive.LoopPrimitive.__init__(self, robot, refresh_freq,
                                                amp, freq, offset, phase)
 
+        self.freq = freq
+        self.amp = amp
+        self.offset = offset
+        self.phase = phase
+
         self.motor_list = [self.get_mockup_motor(m) for m in motor_list]
 
-    def update(self, amp, freq, offset, phase):
+    def update(self):
         """ Compute the sin(t) where t is the elapsed time since the primitive has been started. """
-        pos = amp * numpy.sin(freq * 2.0 * numpy.pi * self.elapsed_time +
-                              phase * numpy.pi / 180.0) + offset
+        pos = self.amp * numpy.sin(self.freq * 2.0 * numpy.pi * self.elapsed_time +
+                              self.phase * numpy.pi / 180.0) + self.offset
 
         for m in self.motor_list:
             m.goal_position = pos
 
+    @property
+    def frequency(self):
+        return self.freq
+
+    @frequency.setter
+    def frequency(self, new_freq):
+        self.freq = new_freq
+
+    @property
+    def amplitude(self):
+        return self.amp
+
+    @amplitude.setter
+    def amplitude(self, new_amp):
+        self.amp = new_amp
+
+    @property
+    def offset(self):
+        return self.offset
+
+    @offset.setter
+    def offset(self, new_offset):
+        self.offset = new_offset
+
+    @property
+    def phase(self):
+        return self.phase
+
+    @phase.setter
+    def phase(self, new_phase):
+        self.phase = new_phase
+
 
 class Cosinus(Sinus):
-    """ Apply a cosinus on the motor specified as argument. """
+    """ Apply a cosinus on the motor specified as argument. Parameters (amp, offset and phase) should be specified in degree
+    """
     def __init__(self, robot, refresh_freq,
                  motor_list,
                  amp=1, freq=0.5, offset=0, phase=0):
@@ -33,3 +71,4 @@ class Cosinus(Sinus):
         Sinus.__init__(self, robot, refresh_freq,
                        motor_list,
                        amp, freq, offset, phase=(numpy.pi / 2 + phase))
+


### PR DESCRIPTION
Proposition of improvement for the Sinus primitive.

By adding getter/setter to all sinus parameter we can tune, while the sinus is running, the behaviour of the motion. This avoid to stop and override the primitive each time we want to change a parameter.

TODO: Do the same for the phase of the Cosinus primitive.
