### PR TITLE
set motors as broken

### DIFF
--- a/pypot/dynamixel/controller.py
+++ b/pypot/dynamixel/controller.py
@@ -55,7 +55,11 @@ class _DxlController(MotorsController):
     def __init__(self, io, motors, sync_freq=50.):
         MotorsController.__init__(self, io, motors, sync_freq)
 
-        self.ids = [m.id for m in motors]
+        self.ids = [m.id for m in self.working_motors]
+
+    @property
+    def working_motors(self):
+        return [m for m in self.motors if not m._broken]
 
 
 class _DxlRegisterController(_DxlController):
@@ -76,7 +80,7 @@ class _DxlRegisterController(_DxlController):
 
     def get_register(self):
         """ Gets the value from the specified register and sets it to the :class:`~pypot.dynamixel.motor.DxlMotor`. """
-        motors = [m for m in self.motors if hasattr(m, self.varname)]
+        motors = [m for m in self.working_motors if hasattr(m, self.varname)]
         if not motors:
             return
         ids = [m.id for m in motors]
@@ -87,7 +91,7 @@ class _DxlRegisterController(_DxlController):
 
     def set_register(self):
         """ Gets the value from :class:`~pypot.dynamixel.motor.DxlMotor` and sets it to the specified register. """
-        motors = [m for m in self.motors if hasattr(m, self.varname)]
+        motors = [m for m in self.working_motors if hasattr(m, self.varname)]
 
         if not motors:
             return
@@ -99,7 +103,7 @@ class _DxlRegisterController(_DxlController):
 
 class AngleLimitRegisterController(_DxlRegisterController):
     def get_register(self):
-        motors = [m for m in self.motors if hasattr(m, self.varname)]
+        motors = [m for m in self.working_motors if hasattr(m, self.varname)]
         if not motors:
             return
 
@@ -109,16 +113,17 @@ class AngleLimitRegisterController(_DxlRegisterController):
         for m, val in zip(motors, values):
             m.__dict__['lower_limit'], m.__dict__['upper_limit'] = val
 
+
 class _PosSpeedLoadDxlController(_DxlController):
     def setup(self):
         torques = self.io.is_torque_enabled(self.ids)
-        for m, c in zip(self.motors, torques):
+        for m, c in zip(self.working_motors, torques):
             m.compliant = not c
         self._old_torques = torques
 
         values = self.io.get_goal_position_speed_load(self.ids)
         positions, speeds, loads = zip(*values)
-        for m, p, s, l in zip(self.motors, positions, speeds, loads):
+        for m, p, s, l in zip(self.working_motors, positions, speeds, loads):
             m.__dict__['goal_position'] = p
             m.__dict__['moving_speed'] = s
             m.__dict__['torque_limit'] = l
@@ -135,22 +140,22 @@ class _PosSpeedLoadDxlController(_DxlController):
 
         positions, speeds, loads = zip(*values)
 
-        for m, p, s, l in zip(self.motors, positions, speeds, loads):
+        for m, p, s, l in zip(self.working_motors, positions, speeds, loads):
             m.__dict__['present_position'] = p
             m.__dict__['present_speed'] = s
             m.__dict__['present_load'] = l
 
     def set_goal_position_speed_load(self):
         change_torque = {}
-        torques = [not m.compliant for m in self.motors]
-        for m, t, old_t in zip(self.motors, torques, self._old_torques):
+        torques = [not m.compliant for m in self.working_motors]
+        for m, t, old_t in zip(self.working_motors, torques, self._old_torques):
             if t != old_t:
                 change_torque[m.id] = t
         self._old_torques = torques
         if change_torque:
             self.io._set_torque_enable(change_torque)
 
-        rigid_motors = [m for m in self.motors if not m.compliant]
+        rigid_motors = [m for m in self.working_motors if not m.compliant]
         ids = tuple(m.id for m in rigid_motors)
 
         if not ids:

--- a/pypot/dynamixel/motor.py
+++ b/pypot/dynamixel/motor.py
@@ -100,7 +100,8 @@ class DxlMotor(Motor):
     present_temperature = DxlRegister()
 
     def __init__(self, id, name=None, model='',
-                 direct=True, offset=0.0):
+                 direct=True, offset=0.0,
+                 broken=False):
         self.__dict__['id'] = id
 
         name = name if name is not None else 'motor_{}'.format(id)
@@ -115,6 +116,8 @@ class DxlMotor(Motor):
         self._safe_compliance = SafeCompliance(self)
         self.goto_behavior = 'dummy'
         self.compliant_behavior = 'dummy'
+
+        self._broken = broken
 
     def __repr__(self):
         return ('<DxlMotor name={self.name} '
@@ -232,8 +235,8 @@ class DxlAXRXMotor(DxlMotor):
     compliance_slope = DxlRegister(rw=True)
 
     def __init__(self, id, name=None, model='',
-                 direct=True, offset=0.0):
-        DxlMotor.__init__(self, id, name, model, direct, offset)
+                 direct=True, offset=0.0, broken=False):
+        DxlMotor.__init__(self, id, name, model, direct, offset, broken)
         self.max_pos = 150
 
 
@@ -243,14 +246,14 @@ class DxlMXMotor(DxlMotor):
     pid = DxlRegister(rw=True)
 
     def __init__(self, id, name=None, model='',
-                 direct=True, offset=0.0):
+                 direct=True, offset=0.0, broken=False):
         """ This class represents the RX and MX robotis motor.
 
             This class adds access to:
                 * PID gains (see the robotis website for details)
 
             """
-        DxlMotor.__init__(self, id, name, model, direct, offset)
+        DxlMotor.__init__(self, id, name, model, direct, offset, broken)
         self.max_pos = 180
 
 


### PR DESCRIPTION
You can now set motors as "broken" in the configuration. They will not be synchronised anymore.