### PR TITLE
fix LialgError : Singular matrix if duration in goto is set to 0

### DIFF
--- a/pypot/utils/trajectory.py
+++ b/pypot/utils/trajectory.py
@@ -82,7 +82,7 @@ class GotoMinJerk(StoppableLoopThread):
         self.t0 = time.time()
 
     def update(self):
-        if numpy.finfo(float).eps < self.duration < self.elapsed_time:
+        if numpy.finfo(float).eps < self.duration > self.elapsed_time:
             self.motor.goal_position = self.trajs(self.elapsed_time)
         else:
             self.stop(wait=False)

--- a/pypot/utils/trajectory.py
+++ b/pypot/utils/trajectory.py
@@ -77,16 +77,15 @@ class GotoMinJerk(StoppableLoopThread):
         if self.duration < numpy.finfo(float).eps:
             self.motor.goal_position = self.goal
             self.stop()
-        else :
+        else:
             self.trajs = MinimumJerkTrajectory(self.motor.present_position, self.goal, self.duration).get_generator()
         self.t0 = time.time()
 
     def update(self):
-        if not (numpy.finfo(float).eps < self.duration > self.elapsed_time):
+        if numpy.finfo(float).eps < self.duration < self.elapsed_time:
+            self.motor.goal_position = self.trajs(self.elapsed_time)
+        else:
             self.stop(wait=False)
-            return
-
-        self.motor.goal_position = self.trajs(self.elapsed_time)
 
     @property
     def elapsed_time(self):

--- a/pypot/utils/trajectory.py
+++ b/pypot/utils/trajectory.py
@@ -74,11 +74,15 @@ class GotoMinJerk(StoppableLoopThread):
         self.duration = duration  # seconds
 
     def setup(self):
-        self.trajs = MinimumJerkTrajectory(self.motor.present_position, self.goal, self.duration).get_generator()
+        if self.duration < numpy.finfo(float).eps:
+            self.motor.goal_position = self.goal
+            self.stop()
+        else :
+            self.trajs = MinimumJerkTrajectory(self.motor.present_position, self.goal, self.duration).get_generator()
         self.t0 = time.time()
 
     def update(self):
-        if self.elapsed_time > self.duration:
+        if not (numpy.finfo(float).eps < self.duration > self.elapsed_time):
             self.stop(wait=False)
             return
 


### PR DESCRIPTION
This exception was raised if the duration attribute was set to '0' in the goto_position method : 

```
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/theo/Documents/code/pypot/pypot/utils/stoppablethread.py", line 113, in _wrapped_target
    self._setup()
  File "/home/theo/Documents/code/pypot/pypot/utils/trajectory.py", line 77, in setup
    self.trajs = MinimumJerkTrajectory(self.motor.present_position, self.goal, self.duration).get_generator()
  File "/home/theo/Documents/code/pypot/pypot/utils/trajectory.py", line 23, in __init__
    self.compute()
  File "/home/theo/Documents/code/pypot/pypot/utils/trajectory.py", line 33, in compute
    X = numpy.linalg.solve(A, B)
  File "/usr/lib/python2.7/dist-packages/numpy/linalg/linalg.py", line 381, in solve
    r = gufunc(a, b, signature=signature, extobj=extobj)
  File "/usr/lib/python2.7/dist-packages/numpy/linalg/linalg.py", line 90, in _raise_linalgerror_singular
    raise LinAlgError("Singular matrix")
LinAlgError: Singular matrix
```