### PR TITLE
Support for Herkulex servos and combination with Dynamixel servos in a single robot

### DIFF
--- a/hangy_code_test_v2.py
+++ b/hangy_code_test_v2.py
@@ -4,7 +4,10 @@ import pypot.robot
 import numpy
 import pypot.primitive
 
+#windows
 eligible_ports = {'Herkulex' : ('COM4',),'Dynamixel' : ('COM3',)}
+#linux
+#eligible_ports = {'Herkulex' : ('/dev/ttyUSB0',),'Dynamixel' : ('/dev/ttyACM0',)}
 crossfile = 'hangy_config_v2.json'
 
 neutral_position={'leg1_base' : -90,
@@ -13,8 +16,8 @@ neutral_position={'leg1_base' : -90,
             'leg2_base' : -90,
             'leg2_joint1' :-80,
             'leg2_joint2' : -45,
-            'puller1' : -90,
-            'puller2' : -90}
+            'puller1' : 0,
+            'puller2' : 0}
 
 class SwingPrimitive(pypot.primitive.Primitive):
     def run(self, amp=70, freq=0.25):
@@ -29,13 +32,10 @@ class SwingPrimitive(pypot.primitive.Primitive):
 if __name__ == '__main__':
     test_robot=pypot.robot.from_json(crossfile, eligible_ports)
     test_robot.compliant = False
-    for m in test_robot.motors:
-        print('for %s: min %s, max %s, current %s' %(m.name, m.lower_limit, m.upper_limit, m.present_position))
     print('to neutral')
     test_robot.goto_position(neutral_position, 2)
     time.sleep(3)
-    for m in test_robot.motors:
-        print('for %s: min %s, max %s' %(m.name, m.lower_limit, m.upper_limit))
+    print('swing')
     swing = SwingPrimitive(test_robot)
     swing.start()
     swing.stop()

--- a/hangy_code_test_v2.py
+++ b/hangy_code_test_v2.py
@@ -1,0 +1,47 @@
+
+import time
+import pypot.robot
+import numpy
+import pypot.primitive
+
+eligible_ports = {'Herkulex' : ('COM4',),'Dynamixel' : ('COM3',)}
+crossfile = 'hangy_config_v2.json'
+
+neutral_position={'leg1_base' : -90,
+            'leg1_joint1' : -80,
+            'leg1_joint2' : -45,
+            'leg2_base' : -90,
+            'leg2_joint1' :-80,
+            'leg2_joint2' : -45,
+            'puller1' : -90,
+            'puller2' : -90}
+
+class SwingPrimitive(pypot.primitive.Primitive):
+    def run(self, amp=70, freq=0.25):
+        while self.elapsed_time < 5:
+            x = -(amp * numpy.sin(2 * numpy.pi * freq * self.elapsed_time + numpy.pi/2)+20)
+            for m in self.robot.motors:
+                self.robot.leg1_base.goto_position(x,0.02)
+                self.robot.leg2_base.goto_position(x,0.02)
+            time.sleep(0.02)
+
+
+if __name__ == '__main__':
+    test_robot=pypot.robot.from_json(crossfile, eligible_ports)
+    test_robot.compliant = False
+    for m in test_robot.motors:
+        print('for %s: min %s, max %s, current %s' %(m.name, m.lower_limit, m.upper_limit, m.present_position))
+    print('to neutral')
+    test_robot.goto_position(neutral_position, 2)
+    time.sleep(3)
+    for m in test_robot.motors:
+        print('for %s: min %s, max %s' %(m.name, m.lower_limit, m.upper_limit))
+    swing = SwingPrimitive(test_robot)
+    swing.start()
+    swing.stop()
+    print('to neutral')
+    test_robot.goto_position(neutral_position, 2)
+    time.sleep(3)
+    test_robot.compliant = True
+    test_robot.close()
+    print('done!')

--- a/hangy_config_v2.json
+++ b/hangy_config_v2.json
@@ -1,0 +1,117 @@
+{
+  "controllers": {
+	"hkx_controller": {
+      "sync_read": false,
+      "attached_motors": [
+        "leg1",
+        "leg2"
+      ],
+      "port": "auto"
+    },
+    "dxl_controller": {
+      "sync_read": false,
+      "attached_motors": [
+        "pullers"
+      ],
+      "port": "auto"
+    }
+  },
+  "motorgroups": {
+    "leg1": [
+      "leg1_base",
+	 "leg1_joint1",
+	 "leg1_joint2"
+    ],
+    "leg2": [
+      "leg2_base",
+	 "leg2_joint1",
+	 "leg2_joint2"
+    ],
+    "pullers": [
+      "puller1",
+	 "puller2"
+    ]
+  },
+  "motors": {
+    "puller1": {
+      "offset": 0.0,
+      "type": "AX-12",
+      "id": 1,
+      "angle_limit": [
+        -100.0,
+        100.0
+      ],
+      "orientation": "direct"
+    },
+    "puller2": {
+      "offset": 0.0,
+      "type": "AX-12",
+      "id": 2,
+      "angle_limit": [
+        -100.0,
+        100.0
+      ],
+      "orientation": "indirect"
+    },
+    "leg1_base": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 1,
+      "angle_limit": [
+        -150.0,
+        150.0
+      ],
+      "orientation": "direct"
+    },
+    "leg1_joint1": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 2,
+      "angle_limit": [
+        -150.0,
+        150.0
+      ],
+      "orientation": "direct"
+    },
+    "leg1_joint2": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 3,
+      "angle_limit": [
+        -150.0,
+        150.0
+      ],
+      "orientation": "direct"
+    },
+    "leg2_base": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 4,
+      "angle_limit": [
+        -150.0,
+        150.0
+      ],
+      "orientation": "indirect"
+    },
+    "leg2_joint1": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 5,
+      "angle_limit": [
+        -150.0,
+        150.0
+      ],
+      "orientation": "indirect"
+    },
+    "leg2_joint2": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 6,
+      "angle_limit": [
+        -150.0,
+        150.0
+      ],
+      "orientation": "indirect"
+    }
+  }
+}

--- a/pypot/herkulex/__init__.py
+++ b/pypot/herkulex/__init__.py
@@ -1,0 +1,4 @@
+from .io import HkxIO, HkxError
+from .error import HkxBaseErrorHandler
+from .controller import BaseHkxController
+from .motor import HkxMotor

--- a/pypot/herkulex/controller.py
+++ b/pypot/herkulex/controller.py
@@ -1,0 +1,180 @@
+import time
+import itertools
+
+from pypot.robot.controller import MotorsController
+
+
+class HkxController(MotorsController):
+    """ Synchronizes the reading/writing of :class:`~pypot.herkulex.motor.HkxMotor` with the real motors.
+
+        This class handles synchronization loops that automatically read/write values from the "software" :class:`~pypot.herkulex.motor.HkxMotor` with their "hardware" equivalent. Those loops shared a same :class:`~pypot.herkulex.io.HkxIO` connection to avoid collision in the bus. Each loop run within its own thread as its own frequency.
+
+        .. warning:: As all the loop attached to a controller shared the same bus, you should make sure that they can run without slowing down the other ones.
+
+        """
+    def __init__(self, io, motors, controllers):
+        MotorsController.__init__(self, io, motors, 1.)
+        self.controllers = controllers
+
+    def setup(self):
+        """ Starts all the synchronization loops. """
+        [c.start() for c in self.controllers]
+        [c.wait_to_start() for c in self.controllers]
+
+    def update(self):
+        pass
+
+    def teardown(self):
+        """ Stops the synchronization loops. """
+        [c.stop() for c in self.controllers]
+
+
+class BaseHkxController(HkxController):
+    """ Implements a basic controller that synchronizes the most frequently used values.
+
+    More precisely, this controller:
+        * reads the present position, speed, load at 50Hz
+        * reads the angle limits, present voltage and temperature at 1Hz
+
+    """
+    def __init__(self, io, motors):
+        factory = _HkxRegisterController
+
+        controllers = [_PosSpeedLoadHkxController(io, motors, 50),
+                       AngleLimitRegisterController(io, motors,
+                                                    1, 'get', 'angle_limit'),
+                       factory(io, motors, 1, 'get', 'present_voltage_temperature')]
+
+        models = set(m.model for m in motors)
+
+        HkxController.__init__(self, io, motors, controllers)
+
+
+class _HkxController(MotorsController):
+    def __init__(self, io, motors, sync_freq=50.):
+        MotorsController.__init__(self, io, motors, sync_freq)
+
+        self.ids = [m.id for m in self.working_motors]
+
+    @property
+    def working_motors(self):
+        return [m for m in self.motors if not m._broken]
+
+
+class _HkxRegisterController(_HkxController):
+    def __init__(self, io, motors, sync_freq,
+                 mode, regname, varname=None):
+        _HkxController.__init__(self, io, motors, sync_freq)
+
+        self.mode = mode
+        self.regname = regname
+        self.varname = regname if varname is None else varname
+
+    def setup(self):
+        if self.mode == 'set':
+            MAX_TRIALS = 25
+            for _ in range(MAX_TRIALS):
+                if self.get_register():
+                    break
+                time.sleep(0.1)
+            else:
+                raise IOError('Cannot initialize syncloop for "{}"'.format(
+                              self.regname))
+
+    def update(self):
+        self.get_register() if self.mode == 'get' else self.set_register()
+
+    def get_register(self):
+        """ Gets the value from the specified register and sets it to the :class:`~pypot.herkulex.motor.HkxMotor`. """
+        motors = [m for m in self.working_motors if hasattr(m, self.varname)]
+        if not motors:
+            return False
+        ids = [m.id for m in motors]
+
+        values = getattr(self.io, 'get_{}'.format(self.regname))(ids)
+        if not values:
+            return False
+
+        for m, val in zip(motors, values):
+            m.__dict__[self.varname] = val
+
+        return True
+
+    def set_register(self):
+        """ Gets the value from :class:`~pypot.herkulex.motor.HkxMotor` and sets it to the specified register. """
+        motors = [m for m in self.working_motors if hasattr(m, self.varname)]
+
+        if not motors:
+            return
+        ids = [m.id for m in motors]
+
+        values = (m.__dict__[self.varname] for m in motors)
+        getattr(self.io, 'set_{}'.format(self.regname))(dict(list(zip(ids, values))))
+
+
+class AngleLimitRegisterController(_HkxRegisterController):
+    def get_register(self):
+        motors = [m for m in self.working_motors if hasattr(m, self.varname)]
+        if not motors:
+            return
+
+        ids = [m.id for m in motors]
+        values = self.io.get_angle_limit(ids)
+
+        for m, val in zip(motors, values):
+            m.__dict__['lower_limit'], m.__dict__['upper_limit'] = val
+
+
+class _PosSpeedLoadHkxController(_HkxController):
+    def setup(self):
+        #dumb-down the motors to have a rectangular speed profile (like other brands)
+        #self.io.set_max_accel_time(dict(zip(self.ids, itertools.repeat(0.0)))) #TODO uncomment if needed
+        #
+        torques = self.io.is_torque_enabled(self.ids)
+        for m, c in zip(self.working_motors, torques):
+            m.compliant = not c
+        self._old_torques = torques
+
+        loads = self.io.get_torque_limit(self.ids)
+        goalpos = self.io.get_goal_position(self.ids)
+        for m, l, p in zip(self.working_motors, loads, goalpos):
+            m.__dict__['torque_limit'] = l
+            m.__dict__['_goal_position'] = p
+        self.get_present_position_speed_load()
+
+    def update(self):
+        self.get_present_position_speed_load()
+        self.set_joint_jog_load()
+
+    def get_present_position_speed_load(self):
+        values = self.io.get_present_position_speed_load(self.ids)
+        if not values:
+            return
+        positions, speeds, loads = zip(*values)
+        for m, p, s, l in zip(self.working_motors, positions, speeds, loads):
+            m.__dict__['present_position'] = p
+            m.__dict__['present_speed'] = s
+            m.__dict__['present_load'] = l
+
+    def set_joint_jog_load(self):
+        change_torque = {}
+        torques = [not m.compliant for m in self.working_motors]
+        for m, t, old_t in zip(self.working_motors, torques, self._old_torques):
+            if t != old_t:
+                change_torque[m.id] = t
+        self._old_torques = torques
+        if change_torque:
+            self.io._set_torque_enable(change_torque)
+        rigid_motors = [m for m in self.working_motors if not m.compliant]
+        ids = tuple(m.id for m in rigid_motors)
+        if not ids:
+            return
+        #only issue a jog command if a goto_position was called i.e. exec time > 0
+        values = ((m.__dict__['_goal_position'],
+                   m.__dict__['_exec_time'],
+                   m.__dict__['torque_limit']) for m in rigid_motors if m.__dict__['_exec_time'] > 0)
+        rigid_motors_to_jog = [m for m in rigid_motors if m.__dict__['_exec_time'] > 0]
+        ids = tuple(m.id for m in rigid_motors_to_jog)
+        self.io.set_joint_jog_load(dict(list(zip(ids, values))))
+        for m in self.working_motors:
+            m.__dict__['_exec_time'] = -1 #indicate that there is no outstanding jog command

--- a/pypot/herkulex/controller.py
+++ b/pypot/herkulex/controller.py
@@ -120,7 +120,6 @@ class AngleLimitRegisterController(_HkxRegisterController):
 
         ids = [m.id for m in motors]
         values = self.io.get_angle_limit(ids)
-        print('controller getting angle limit')
 
         for m, val in zip(motors, values):
             m.__dict__['lower_limit'], m.__dict__['upper_limit'] = val
@@ -144,6 +143,7 @@ class _PosSpeedLoadHkxController(_HkxController):
         self.get_present_position_speed_load()
 
     def update(self):
+        t0=time.time()
         self.get_present_position_speed_load()
         self.set_joint_jog_load()
 

--- a/pypot/herkulex/conversion.py
+++ b/pypot/herkulex/conversion.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+
+
+"""
+    This module describes all the conversion method used to transform value from the representation used by the herkulex motor to a more standard form (e.g. degrees, volt...).
+
+    For compatibility issue all comparison method should be written in the following form (even if the model is not actually used):
+        * def my_conversion_from_hkx_to_si(value, model): ...
+        * def my_conversion_from_si_to_hkx(value, model): ...
+
+    .. note:: If the control is readonly you only need to write the hkx_to_si conversion.
+
+    """
+
+import numpy
+import itertools
+
+from enum import Enum
+
+hkx_max_playtime = 2.856  #the maximum playtime for JOG commands (in secs)
+hkx_max_speed = 360    #the maximum speed in deg/sec
+
+# MARK: - Model
+
+herkulexModels = {
+    257: 'DRS-0101',
+    513: 'DRS-0201',
+    1025: 'DRS-0401',
+    1026: 'DRS-0402',
+    1537: 'DRS-0601',
+    1538: 'DRS-0602',
+}
+
+def hkx_to_model(value, dummy=None):
+    return herkulexModels[value]
+
+
+# MARK: - Position
+
+position_range = {
+    'DRS-0101': (1024, 333.3)
+}
+
+def hkx_to_degree(value, model):
+    max_pos, max_deg = position_range[model]
+    return round(((max_deg * float(value)) / (max_pos - 1)) - (max_deg / 2), 2)
+
+
+def degree_to_hkx(value, model):
+    max_pos, max_deg = position_range[model]
+    pos = int(round((max_pos - 1) * ((max_deg / 2 + float(value)) / max_deg), 0))
+    pos = min(max(pos, 0), max_pos - 1)
+    return pos
+
+
+# MARK: - Speed
+
+def hkx_to_speed(value, model):
+    return value
+
+def speed_to_hkx(value, model):
+    return value
+
+
+# MARK: - Torque value
+#TODO
+def hkx_to_torque(value, model):
+    return value
+
+
+def torque_to_hkx(value, model):
+    return value
+
+
+def hkx_to_load(value, model):
+    return value
+
+
+# MARK: - Torque mode
+
+torque_control_modes = {
+    'BREAK_ON' : 0x40,
+    'TORQUE_ON' : 0x60,
+    'TORQUE_FREE' : 0x00,
+}
+
+def hkx_to_torque_enabled(value, model):
+    return value == torque_control_modes['TORQUE_ON']
+
+def torque_enabled_to_hkx(value, model):
+    res = torque_control_modes['TORQUE_ON']
+    if not value:
+        res = torque_control_modes['TORQUE_FREE']
+    return res
+    
+    
+# MARK: - Control mode
+
+def hkx_to_control_mode(value, model):
+    if value == 0:
+        res = 'joint'        
+    elif value == 1:
+        res = 'wheel'
+    return res
+
+def control_mode_to_hkx(value, model):
+    if value == 'wheel':
+        res = 0       
+    elif value == 'joint':
+        res = 1
+    return res
+
+
+# MARK: - Status data
+
+status_detail_bits = {
+    0: "Moving",
+    1: "In_position",
+    2: "Invalid packet: checksum error",
+    3: "Invalid packet: unknown command",
+    4: "Invalid packet: exceed REG range",
+    5: "Invalid packet: garbage detected",
+    6: "MOTOR_ON",
+    7: "reserved",
+    }
+
+def hkx_to_status_detail(value, model):
+    return [status_detail_bits[a] for a in status_detail_bits if check_bit(value, int(a))]
+
+
+# MARK: - Baudrate
+
+herculexBaudrates = {
+    0x02: 666666.0,
+    0x03: 500000.0,
+    0x04: 400000.0,
+    0x07: 250000.0,
+    0x09: 200000.0,
+    0x10: 115200.0,
+    0x22: 57600.0,
+}
+
+def hkx_to_baudrate(value, model):
+    return herculexBaudrates[value]
+
+
+def baudrate_to_hkx(value, model):
+    for k, v in herculexlBaudrates.iteritems():
+        if (abs(v - value) / float(value)) < 0.05:
+            return k
+    raise ValueError('incorrect baudrate {} (possible values {})'.format(value, herculex.values()))
+
+
+# MARK: - Temperature
+##TODO: add tabulated values
+def hkx_to_temperature(value, model):
+    return int(value)
+
+
+def temperature_to_hkx(value, model):
+    return int(value)
+
+
+# MARK: - time (ticks vs s)
+
+def hkx_to_time(value, model):
+    return float(value * 0.0112)
+
+
+def time_to_hkx(value, model):
+    res = int(value / 0.0112)
+    return res
+
+# MARK: - Voltage
+
+voltage_factor = {
+    'DRS-0101': 0.074075,
+    'DRS-0602': 0.1,
+}
+
+def hkx_to_voltage(value, model):
+    return value * voltage_factor[model]
+
+
+def voltage_to_hkx(value, model):
+    return int(value / voltage_factor[model])
+
+
+# MARK: - led color
+
+LEDColors = Enum('Colors', 'off green blue cyan red yellow pink white')
+
+def hkx_to_LED(value, model):
+    return LEDColors(value + 1).name
+
+
+def LED_to_hkx(value, model):
+    value = getattr(LEDColors, value).value - 1
+    value = int(value) & 0b111
+    return value
+
+
+# MARK: - acceleration ratio
+
+def accel_ratio_to_hkx(value, model):
+    if value < 0 or value > 0.5:
+        raise ValueError('acceleration ratio must be between 0 and 50%')
+    res = int(value * 100)
+    return res
+
+# MARK: - Error
+
+herkulexErrors = [ 'reserved',
+                   'EEP REG distorted Error',
+                   'Driver fault Error',
+                   'Overload Error',
+                   'Invalid packet Error',
+                   'Overheating Error',
+                   'Angle Limit Error',
+                   'Input Voltage Error']
+
+def hkx_to_status_error(value, model):
+    return decode_error(value)
+
+    
+def decode_error(error_code):
+    bits = numpy.unpackbits(numpy.asarray(error_code, dtype=numpy.uint8))
+    return tuple(numpy.array(herkulexErrors)[bits == 1])
+
+
+# MARK: - Various utility functions
+
+def check_bit(value, offset):
+    return bool(value & (1 << offset))
+    
+def hkx_decode(data):
+    if len(data) not in (1, 2):
+        raise ValueError('try to decode incorrect data {}'.format(data))
+
+    if len(data) == 1:
+        return data[0]
+
+    if len(data) == 2:
+        return data[0] + (data[1] << 8)
+
+
+def hkx_decode_all(data, nb_elem):
+    if nb_elem > 1:
+        data = list(itertools.izip(*([iter(data)] * (len(data) // nb_elem))))
+        return tuple(map(hkx_decode, data))
+    else:
+        return hkx_decode(data)
+
+
+def hkx_code(value, length):
+    if length not in (1, 2):
+        raise ValueError('try to code value with an incorrect length {}'.format(length))
+
+    if length == 1:
+        return (value, )
+
+    if length == 2:
+        return (value % 256, value >> 8)
+
+
+def hkx_code_all(value, length, nb_elem):
+    if nb_elem > 1:
+        return list(itertools.chain(*(hkx_code(v, length) for v in value)))
+    else:
+        return hkx_code(value, length)

--- a/pypot/herkulex/error.py
+++ b/pypot/herkulex/error.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class HkxErrorHandler(object):
+    """ This class is used to represent all the error that you can/should handle.
+
+        The errors can be of two types:
+
+        * communication error (timeout, communication)
+        * motor error (voltage, limit, overload...)
+
+        This class was designed as an abstract class and so you should write your own handler by subclassing this class and defining the apropriate behavior for your program.
+
+        .. warning:: The motor error should be overload carrefuly as they can indicate important mechanical issue.
+
+        """
+    # MARK: - Communication errors
+
+    def handle_timeout(self, timeout_error):
+        raise NotImplementedError
+
+    def handle_communication_error(self, communication_error):
+        raise NotImplementedError
+
+    # MARK: - Motor errors, must match herkulexError names
+
+    def handle_reserved_error(self, instruction_packet):
+        raise NotImplementedError
+
+    def handle_eep_reg_distorted_error(self, instruction_packet):
+        raise NotImplementedError
+        
+    def handle_driver_fault_error(self, instruction_packet):
+        raise NotImplementedError
+
+    def handle_overload_error(self, instruction_packet):
+        raise NotImplementedError
+
+    def handle_invalid_packet_error(self, instruction_packet):
+        raise NotImplementedError
+        
+    def handle_overheating_error(self, instruction_packet):
+        raise NotImplementedError
+
+    def handle_angle_limit_error(self, instruction_packet):
+        raise NotImplementedError
+
+    def handle_input_voltage_error(self, instruction_packet):
+        raise NotImplementedError
+
+class HkxBaseErrorHandler(HkxErrorHandler):
+    """ This class is a basic handler that just skip the communication errors. """
+    def handle_timeout(self, timeout_error):
+        msg = 'Timeout after sending {} to motors {}'.format(timeout_error.instruction_packet,
+                                                             timeout_error.ids)
+        logger.warning(msg,
+                       extra={'port': timeout_error.hkx_io.port,
+                              'baudrate': timeout_error.hkx_io.baudrate,
+                              'timeout': timeout_error.hkx_io.timeout})
+
+    def handle_communication_error(self, com_error):
+        msg = 'Communication error after sending {}'.format(com_error.instruction_packet)
+
+        logger.warning(msg,
+                       extra={'port': com_error.hkx_io.port,
+                              'baudrate': com_error.hkx_io.baudrate,
+                              'timeout': com_error.hkx_io.timeout})

--- a/pypot/herkulex/io/__init__.py
+++ b/pypot/herkulex/io/__init__.py
@@ -1,0 +1,2 @@
+from .io import HkxIO
+from .abstract_io import HkxError

--- a/pypot/herkulex/io/abstract_io.py
+++ b/pypot/herkulex/io/abstract_io.py
@@ -1,0 +1,554 @@
+# -*- coding: utf-8 -*-
+
+import serial
+import logging
+import operator
+import itertools
+import threading
+import time
+
+from ..protocol import *
+
+from collections import namedtuple, OrderedDict
+from contextlib import contextmanager
+
+from pypot.robot.io import AbstractIO
+from ..conversion import *
+
+
+logger = logging.getLogger(__name__)
+# With this logger you should always provide as extra:
+# - the port
+# - the baudrate
+# - the timeout
+
+
+_HkxControl = namedtuple('_HkxControl', ('name', 'eeprom_ram',
+                                         'address', 'length', 'nb_elem',
+                                         'access',
+                                         'models',
+                                         'hkx_to_si', 'si_to_hkx',
+                                         'getter_name', 'setter_name'))
+
+
+class _HkxAccess(object):
+    readonly, writeonly, readwrite = range(3)
+
+
+class AbstractHkxIO(AbstractIO):
+    """ Low-level class to handle the serial communication with the dongbu robot motors. """
+
+    __used_ports = set()
+    __controls = []
+    _protocol = None
+
+    # MARK: - Open, Close and Flush the communication
+
+    def __init__(self,
+                 port, baudrate=115200, timeout=0.05,
+                 use_sync_read=False,
+                 error_handler_cls=None,
+                 convert=True):
+        """ At instanciation, it opens the serial port and sets the communication parameters.
+
+            :param string port: the serial port to use (e.g. Unix (/dev/tty...), Windows (COM...)).
+            :param int baudrate: default 666666 (vs 115200 factory settings) 
+            :param float timeout: read timeout in seconds
+            :param bool use_sync_read: whether or not to use the SYNC_READ instruction
+            :param error_handler: set a handler that will receive the different errors
+            :type error_handler: :py:class:`~pypot.herkulex.error.HkxErrorHandler`
+            :param bool convert: whether or not convert values to units expressed in the standard system
+
+            :raises: :py:exc:`~pypot.herkulex.io.HkxError` if the port is already used.
+
+            """
+        self._known_models = {}
+        self._known_mode = {}
+
+        self._sync_read = use_sync_read
+        self._error_handler = error_handler_cls() if error_handler_cls else None
+        self._convert = convert
+
+        self._serial_lock = threading.Lock()
+
+        self.open(port, baudrate, timeout)
+
+    def __enter__(self):
+        return self
+
+    def __del__(self):
+        self.close()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def __repr__(self):
+        return ('<HKX IO: closed={self.closed}, '
+                'port="{self.port}", '
+                'baudrate={self.baudrate}, '
+                'timeout={self.timeout}>').format(self=self)
+
+    def open(self, port, baudrate=115200, timeout=0.05):
+        """ Opens a new serial communication (closes the previous communication if needed).
+
+            :raises: :py:exc:`~pypot.herkulex.io.HkxError` if the port is already used.
+
+            """
+        self._open(port, baudrate, timeout)
+        logger.info("Opening port '%s'", self.port,
+                    extra={'port': port,
+                           'baudrate': baudrate,
+                           'timeout': timeout})
+
+    def _open(self, port, baudrate, timeout, max_recursion=500):
+        # Tries to connect to port until it succeeds to ping any motor on the bus
+        # Warning: If no motor is connected on the bus, this will run forever!!!
+        import platform
+        # import time
+        import pypot.utils.pypot_time as time
+        #TODO: check on Linux and Darwin platforms
+        for i in range(max_recursion):
+            self._known_models.clear()
+            self._known_mode.clear()
+
+            with self._serial_lock:
+                self.close(_force_lock=True)
+
+                if port in self.__used_ports:
+                    raise HkxError('port already used {}'.format(port))
+
+                self._serial = serial.Serial(port, baudrate, timeout=timeout)
+                self.__used_ports.add(port)
+
+            break
+        else:
+            raise HkxError('could not connect to the port {}'.format(self.port))
+
+    def close(self, _force_lock=False):
+        """ Closes the serial communication if opened. """
+        if not self.closed:
+            with self.__force_lock(_force_lock) or self._serial_lock:
+                self._serial.close()
+                self.__used_ports.remove(self.port)
+
+            logger.info("Closing port '%s'", self.port,
+                        extra={'port': self.port,
+                               'baudrate': self.baudrate,
+                               'timeout': self.timeout})
+
+    def flush(self, _force_lock=False):
+        """ Flushes the serial communication (both input and output). """
+        if self.closed:
+            raise HkxError('attempt to flush a closed serial communication')
+
+        with self.__force_lock(_force_lock) or self._serial_lock:
+            self._serial.flushInput()
+            self._serial.flushOutput()
+
+    def __force_lock(self, condition):
+        @contextmanager
+        def with_True():
+            yield True
+
+        return with_True() if condition else False
+
+
+    # MARK: Properties of the serial communication
+
+    @property
+    def port(self):
+        """ Port used by the :class:`~pypot.herkulex.io.HkxIO`. If set, will re-open a new connection. """
+        return self._serial.port
+
+    @port.setter
+    def port(self, value):
+        self.open(value, self.baudrate, self.timeout)
+
+    @property
+    def baudrate(self):
+        """ Baudrate used by the :class:`~pypot.herkulex.io.HkxIO`. If set, will re-open a new connection. """
+        return self._serial.baudrate
+
+    @baudrate.setter
+    def baudrate(self, value):
+        self.open(self.port, value, self.timeout)
+
+    @property
+    def timeout(self):
+        """ Timeout used by the :class:`~pypot.herkulex.io.HkxIO`. If set, will re-open a new connection. """
+        return self._serial.timeout
+
+    @timeout.setter
+    def timeout(self, value):
+        self.open(self.port, self.baudrate, value)
+
+    @property
+    def closed(self):
+        """ Checks if the connection is closed. """
+        return not (hasattr(self, '_serial') and self._serial.isOpen())
+
+    # MARK: - Motor discovery
+
+    def ping(self, id):
+        """ Pings the motor with the specified id.
+
+            .. note:: The motor id should always be included in [0, 253]. 254 is used for broadcast.
+
+            """
+        pp = HkxPingPacket(id)
+
+        try:
+            self._send_packet(pp, error_handler=None)
+            return True
+        except HkxTimeoutError:
+            return False
+
+
+    def scan(self, ids=xrange(254)):
+        """ Pings all ids within the specified list, by default it finds all the motors connected to the bus. """
+        return [id for id in ids if self.ping(id)]
+        
+    # MARK: - Specific Getter / Setter
+
+    def get_model(self, ids):
+        """ Gets the model for the specified motors. """
+        to_get_ids = [i for i in ids if i not in self._known_models]
+        models = [hkx_to_model(m) for m in self._get_model(to_get_ids, convert=False)]
+        self._known_models.update(zip(to_get_ids, models))
+        return tuple(self._known_models[id] for id in ids)
+
+    def change_id(self, new_id_for_id, EEPROM_too = False):
+        """ Changes the id of the specified motors (each id must be unique on the bus). """
+        if len(set(new_id_for_id.values())) < len(new_id_for_id):
+            raise ValueError('each id must be unique.')
+
+        for new_id in new_id_for_id.itervalues():
+            if self.ping(new_id):
+                raise ValueError('id {} is already used.'.format(new_id))
+
+        if EEPROM_too : 
+            self.change_id_EEPROM(new_id_for_id)
+            
+        self._change_id(new_id_for_id)
+
+        for motor_id, new_id in new_id_for_id.iteritems():
+            if motor_id in self._known_models:
+                self._known_models[new_id] = self._known_models[motor_id]
+                del self._known_models[motor_id]
+            if motor_id in self._known_mode:
+                self._known_mode[new_id] = self._known_mode[motor_id]
+                del self._known_mode[motor_id]
+    #TODO: test this function
+    def change_baudrate(self, baudrate_for_ids):
+        """ Changes the baudrate of the specified motors. """
+        self._change_baudrate(baudrate_for_ids)
+
+        for motor_id in baudrate_for_ids:
+            if motor_id in self._known_models:
+                del self._known_models[motor_id]
+            if motor_id in self._known_mode:
+                del self._known_mode[motor_id]
+    #TODO: test this function
+    def get_status_return_level(self, ids, **kwargs):
+        """ Gets the status level for the specified motors. """
+        convert = kwargs['convert'] if 'convert' in kwargs else self._convert
+        srl = []
+        for id in ids:
+            try:
+                srl.extend(self._get_status_return_level((id, ),
+                           error_handler=None, convert=convert))
+            except HkxTimeoutError as e:
+                if self.ping(id):
+                    srl.append('never' if convert else 0)
+                else:
+                    if self._error_handler:
+                        self._error_handler.handle_timeout(e)
+                        return ()
+                    else:
+                        raise e
+
+        return tuple(srl)
+    #TODO: test this function
+    def set_status_return_level(self, srl_for_id, **kwargs):
+        """ Sets status return level to the specified motors. """
+        convert = kwargs['convert'] if 'convert' in kwargs else self._convert
+        if convert:
+            srl_for_id = dict(zip(srl_for_id.keys(),
+                              [('never', 'read', 'always').index(s) for s in srl_for_id.values()]))
+        self._set_status_return_level(srl_for_id, convert=False)
+
+    def switch_led_on(self, ids, color = 'white'):
+        """ Switches on the LED of the motors with the specified ids. """
+        self.set_LED(dict(zip(ids, itertools.repeat(color))))
+
+    def switch_led_off(self, ids):
+        """ Switches off the LED of the motors with the specified ids. """
+        self.set_LED(dict(zip(ids, itertools.repeat('off'))))
+
+    def enable_torque(self, ids):
+        """ Enables torque of the motors with the specified ids. """
+        self.set_torque_enabled(dict(zip(ids, itertools.repeat(True))))
+
+    def disable_torque(self, ids):
+        """ Disables torque of the motors with the specified ids. """
+        self.set_torque_enabled(dict(zip(ids, itertools.repeat(False))))
+
+    #TODO: add PID gain functions?
+
+    # MARK: - Generic Getter / Setter
+    #TODO: create a get_control_table function?
+
+    @classmethod
+    def _generate_accessors(cls, control):
+        cls.__controls.append(control)
+
+        if control.access in (_HkxAccess.readonly, _HkxAccess.readwrite):
+            def my_getter(self, ids, **kwargs):
+                return self._get_control_value(control, ids, **kwargs)
+
+            func_name = control.getter_name if control.getter_name else 'get_{}'.format(control.name.replace(' ', '_'))
+            func_name = '_{}'.format(func_name) if hasattr(cls, func_name) else func_name
+            my_getter.__doc__ = 'Gets {} from the specified motors.'.format(control.name)
+            my_getter.__name__ = func_name
+            setattr(cls, func_name, my_getter)
+
+        if control.access in (_HkxAccess.writeonly, _HkxAccess.readwrite):
+            def my_setter(self, value_for_id, **kwargs):
+                self._set_control_value(control, value_for_id, **kwargs)
+
+            func_name = control.setter_name if control.setter_name else 'set_{}'.format(control.name.replace(' ', '_'))
+            func_name = '_{}'.format(func_name) if hasattr(cls, func_name) else func_name
+            my_setter.__doc__ = 'Sets {} to the specified motors.'.format(control.name)
+            my_setter.__name__ = func_name
+            setattr(cls, func_name, my_setter)
+
+    def _get_control_value(self, control, ids, **kwargs):
+        if not ids:
+            return ()
+        error_handler = kwargs['error_handler'] if ('error_handler' in kwargs) else self._error_handler
+        convert = kwargs['convert'] if ('convert' in kwargs) else self._convert
+
+        values = []
+        for motor_id in ids:
+            rp = HkxReadDataPacket(motor_id, control.eeprom_ram, control.address, control.length * control.nb_elem)
+            sp = self._send_packet(rp, error_handler=error_handler)
+
+            if not sp:
+                return ()
+            values.extend(sp.parameters)
+
+
+        values = list(itertools.izip(*([iter(values)] * control.length * control.nb_elem)))
+        values = [hkx_decode_all(value, control.nb_elem) for value in values]
+
+        if not values:
+            return ()
+
+        if convert:
+            models = self.get_model(ids)
+            if not models:
+                return ()
+            values = [control.hkx_to_si(v, m) for v, m in zip(values, models)]
+
+        return tuple(values)
+
+    def _set_control_value(self, control, value_for_id, **kwargs):
+        if not value_for_id:
+            return
+
+        convert = kwargs['convert'] if ('convert' in kwargs) else self._convert
+
+        if convert:
+            models = self.get_model(value_for_id.keys())
+            if not models:
+                return
+
+            value_for_id = dict(zip(value_for_id.keys(),
+                                    map(control.si_to_hkx, value_for_id.values(), models)))
+
+        for motor_id, value in value_for_id.iteritems():
+            dat=hkx_code_all(value, control.length, control.nb_elem)
+            wp = HkxWriteDataPacket(motor_id, control.eeprom_ram, control.address, control.length, control.nb_elem, dat)
+            self._send_packet(wp, wait_for_status_packet=False)
+            
+            
+    def joint_jog(self, goal_position_time_for_id, **kwargs):
+        if not goal_position_time_for_id:
+            return
+
+        convert = kwargs['convert'] if ('convert' in kwargs) else self._convert
+        set_control_mode_only = kwargs['set_control_mode_only'] if ('set_control_mode_only' in kwargs) else False
+
+        if convert:
+            models = self.get_model(goal_position_time_for_id.keys())
+            if not models:
+                return
+                
+        t=0
+        for id, goal_position_time_led in iter(goal_position_time_for_id.items()):
+            pos = goal_position_time_led[0]
+            tm = goal_position_time_led[1]
+            ld=None
+            if len(goal_position_time_led) > 2:
+                ld = goal_position_time_led[2]
+            
+            if convert :
+                md = models[t]
+                pos = degree_to_hkx(pos, md)
+                tm = time_to_hkx(tm, md)
+                ld = LED_to_hkx(ld, md)
+            
+            ld = (ld << 2) #shift bits and set to wheel
+            pos_msb = int(pos) >> 8
+            pos_lsb = int(pos) & 0xff
+
+            data = (pos_lsb, pos_msb, (set_control_mode_only | ld), id, tm)
+            wp = HkxJogPacket(id,HkxInstruction.I_JOG, data)
+            self._send_packet(wp, wait_for_status_packet=False)
+            t=t+1
+
+    def wheel_jog(self, goal_speed_led_for_id, **kwargs):
+        if not goal_speed_led_for_id:
+            return
+
+        convert = kwargs['convert'] if ('convert' in kwargs) else self._convert
+
+        if convert:
+            models = self.get_model(goal_speed_led_for_id.keys())
+            if not models:
+                return
+                
+        t=0
+        for id, itm in iter(goal_speed_led_for_id.items()):
+            speed = itm[0]
+            ld = None
+            if len(itm) > 1:
+                ld = itm[1]
+            
+            if convert :
+                md = models[t]
+                speed = speed_to_hkx(speed, md)
+                ld = LED_to_hkx(ld, md)
+
+            ld = (ld << 2) | 0x02 #shift bits and set to wheel
+   
+            if(speed>0):
+                goalspeed_msb = (int(speed)& 0xFF00) >> 8
+                goalspeed_lsb = int(speed) & 0xff
+            elif(speed<0):
+                goalspeed_msb = 64+(255- ((int(speed)& 0xFF00) >> 8))
+                goalspeed_lsb = (abs(speed) & 0xff)
+            else:
+                goalspeed_msb = 0x00
+                goalspeed_lsb = 0x00
+                ld=ld | 0x01
+                
+            data = (goalspeed_lsb, goalspeed_msb, ld, id, 0)
+            wp = HkxJogPacket(id,HkxInstruction.I_JOG, data)
+            self._send_packet(wp, wait_for_status_packet=False)
+            t=t+1
+
+
+    # MARK: - Send/Receive packet
+    def __real_send(self, instruction_packet, wait_for_status_packet, _force_lock):
+        if self.closed:
+            raise HkxError('try to send a packet on a closed serial communication')
+
+        logger.debug('Sending %s', instruction_packet,
+                     extra={'port': self.port,
+                            'baudrate': self.baudrate,
+                            'timeout': self.timeout})
+
+        with self.__force_lock(_force_lock) or self._serial_lock:
+            self.flush(_force_lock=True)
+            data = instruction_packet.to_string()
+            nbytes = self._serial.write(data)
+            if len(data) != nbytes:
+                raise HkxCommunicationError(self,
+                                            'instruction packet not entirely sent',
+                                            instruction_packet)
+
+            if not wait_for_status_packet:
+                return
+
+            status_packet = self.__real_read(instruction_packet, _force_lock=True)
+            logger.debug('Receiving %s', status_packet,
+                         extra={'port': self.port,
+                                'baudrate': self.baudrate,
+                                'timeout': self.timeout})
+
+            return status_packet
+
+    def __real_read(self, instruction_packet, _force_lock):
+        with self.__force_lock(_force_lock) or self._serial_lock:
+            t0 = time.time()
+            data = self._serial.read(HkxPacketHeader.length)
+            theader = time.time()
+            headertime = theader - t0
+            if not data:
+                raise HkxTimeoutError(self, instruction_packet, instruction_packet.id)
+
+            try:
+                header = HkxPacketHeader.from_string(data)
+                data += self._serial.read(header.packet_length-4)
+                tdata = time.time()
+                datatime = tdata - theader
+                status_packet = HkxStatusPacket.from_string(data)
+
+            except ValueError:
+                msg = 'could not parse received data {}'.format(bytearray(data))
+                raise HkxCommunicationError(self, msg, instruction_packet)
+
+            return status_packet
+
+    def _send_packet(self,
+                     instruction_packet, wait_for_status_packet=True,
+                     error_handler=None,
+                     _force_lock=False):
+       
+        if not error_handler:
+            return self.__real_send(instruction_packet, wait_for_status_packet, _force_lock)
+
+        try:
+            sp = self.__real_send(instruction_packet, wait_for_status_packet, _force_lock)
+            if sp and sp.error:
+                errors = decode_error(sp.error)
+                for e in errors:
+                    handler_name = 'handle_{}'.format(e.lower().replace(' ', '_'))
+                    f = operator.methodcaller(handler_name, instruction_packet)
+                    f(error_handler)
+
+            return sp
+
+        except HkxTimeoutError as e:
+            error_handler.handle_timeout(e)
+
+        except HkxCommunicationError as e:
+            error_handler.handle_communication_error(e)
+
+
+# MARK: - Hkx Errors
+class HkxError(Exception):
+    """ Base class for all errors encountered using :class:`~pypot.herkulex.io.HkxIO`. """
+    pass
+
+
+class HkxCommunicationError(HkxError):
+    """ Base error for communication error encountered when using :class:`~pypot.herkulex.io.HkxlIO`. """
+    def __init__(self, hkx_io, message, instruction_packet):
+        self.hkx_io = hkx_io
+        self.message = message
+        self.instruction_packet = instruction_packet
+
+    def __str__(self):
+        return '{self.message} after sending {self.instruction_packet}'.format(self=self)
+
+
+class HkxTimeoutError(HkxCommunicationError):
+    """ Timeout error encountered when using :class:`~pypot.herkulex.io.HkxIO`. """
+    def __init__(self, hkx_io, instruction_packet, ids):
+        HkxCommunicationError.__init__(self, hkx_io, 'timeout occured', instruction_packet)
+        self.ids = ids
+
+    def __str__(self):
+        return 'motors {} did not respond after sending {}'.format(self.ids, self.instruction_packet)

--- a/pypot/herkulex/io/io.py
+++ b/pypot/herkulex/io/io.py
@@ -1,0 +1,281 @@
+from .abstract_io import (AbstractHkxIO, _HkxControl,
+                          _HkxAccess, HkxTimeoutError)
+from ..protocol import *
+from ..conversion import *
+
+
+class HkxIO(AbstractHkxIO):
+
+
+    def factory_reset(self):
+        """ Reset all motors on the bus to their factory default settings. """
+        try:
+            self._send_packet(HkxRollBackPacket())
+
+        except HkxTimeoutError:
+            pass
+        
+    #TODO: functions to set wheel and joint modes
+
+    def set_angle_limit(self, limit_for_id, **kwargs):
+        """ Sets the angle limit to the specified motors. """
+        convert = kwargs['convert'] if 'convert' in kwargs else self._convert
+        #TODO: check if there are requirements before changing angle limits
+        self._set_angle_limit(limit_for_id, convert=convert)
+        
+    def get_goal_position_load(self, ids, **kwargs):
+        pos = self.get_goal_position(ids)
+        ld = self.get_torque_limit(ids)
+        return (pos,ld)
+
+    def set_joint_jog_load(self, input_dict):
+        nid = input_dict.keys()
+        nval = [(d[0], d[1], 'off') for d in input_dict.values()]
+        jointjog=dict(list(zip(nid,nval)))
+        self.joint_jog(jointjog, convert = True)
+
+
+# MARK: - Generate the accessors
+
+def _add_control(name, eeprom_ram,
+                 address, length=2, nb_elem=1,
+                 access=_HkxAccess.readwrite,
+                 models=set(herkulexModels.values()),
+                 hkx_to_si=lambda val, model: val,
+                 si_to_hkx=lambda val, model: val,
+                 getter_name=None,
+                 setter_name=None):
+
+    control = _HkxControl(name, eeprom_ram,
+                          address, length, nb_elem,
+                          access,
+                          models,
+                          hkx_to_si, si_to_hkx,
+                          getter_name, setter_name)
+
+    HkxIO._generate_accessors(control)
+
+
+_add_control('model',
+             eeprom_ram = 'EEPROM',
+             address=0,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_model)
+
+_add_control('firmware',
+             eeprom_ram = 'EEPROM',           
+             address=2,
+             access=_HkxAccess.readonly)
+             
+_add_control('baudrate',
+             eeprom_ram = 'EEPROM',  
+             address=4, length=1,
+             access=_HkxAccess.writeonly,
+             setter_name='change_baudrate',
+             si_to_hkx=baudrate_to_hkx)
+
+_add_control('id_EEPROM',
+             eeprom_ram = 'EEPROM', 
+             address=6, length=1,
+             access=_HkxAccess.writeonly,
+             setter_name='change_id_EEPROM')
+
+_add_control('id',
+             eeprom_ram = 'RAM', 
+             address=0, length=1,
+             access=_HkxAccess.writeonly,
+             setter_name='change_id')
+
+_add_control('highest_temperature_limit_EEPROM',
+             eeprom_ram = 'EEPROM', 
+             address=11, length=1,
+             hkx_to_si=hkx_to_temperature,
+             si_to_hkx=temperature_to_hkx)
+
+_add_control('highest_temperature_limit',
+             eeprom_ram = 'RAM', 
+             address=5, length=1,
+             hkx_to_si=hkx_to_temperature,
+             si_to_hkx=temperature_to_hkx)
+
+_add_control('voltage_limit_EEPROM',
+             eeprom_ram = 'EEPROM', 
+             address=12, length=1, nb_elem=2,
+             hkx_to_si=lambda value, model: (hkx_to_voltage(value[0], model),
+                                             hkx_to_voltage(value[1], model)),
+             si_to_hkx=lambda value, model: (voltage_to_hkx(value[0], model),
+                                             voltage_to_hkx(value[1], model)))
+
+_add_control('voltage_limit',
+             eeprom_ram = 'RAM', 
+             address=6, length=1, nb_elem=2,
+             hkx_to_si=lambda value, model: (hkx_to_voltage(value[0], model),
+                                             hkx_to_voltage(value[1], model)),
+             si_to_hkx=lambda value, model: (voltage_to_hkx(value[0], model),
+                                             voltage_to_hkx(value[1], model)))
+
+_add_control('accel_ratio',
+             eeprom_ram = 'RAM', 
+             address=8, length=1,
+             si_to_hkx=accel_ratio_to_hkx)
+
+_add_control('accel_ratio_EEPROM',
+             eeprom_ram = 'EEPROM', 
+             address=14, length=1,
+             si_to_hkx=accel_ratio_to_hkx)
+
+_add_control('max_accel_time',
+             eeprom_ram = 'RAM', 
+             address=9, length=1,
+             hkx_to_si=hkx_to_time,
+             si_to_hkx=time_to_hkx)
+
+_add_control('max_accel_time_EEPROM',
+             eeprom_ram = 'EEPROM', 
+             address=15, length=1,
+             hkx_to_si=hkx_to_time,
+             si_to_hkx=time_to_hkx)
+
+_add_control('compliance_margin_EPPROM',
+             address=16, length=1,
+             eeprom_ram = 'EEPROM')
+
+_add_control('compliance_margin',
+             address=10, length=1,
+             eeprom_ram = 'RAM')
+
+_add_control('compliance_slope_EEPROM',
+             address=18,
+             eeprom_ram = 'EEPROM')
+
+_add_control('compliance_slope',
+             address=12,
+             eeprom_ram = 'RAM')
+             
+             
+_add_control('torque_limit_EEPROM',
+             eeprom_ram = 'EEPROM', 
+             address=22,
+             hkx_to_si=hkx_to_torque,
+             si_to_hkx=torque_to_hkx)
+
+_add_control('torque_limit',
+             eeprom_ram = 'RAM', 
+             address=16,
+             hkx_to_si=hkx_to_torque,
+             si_to_hkx=torque_to_hkx)
+
+_add_control('angle_limit_EEPROM',
+             eeprom_ram = 'EEPROM', 
+             address=26, nb_elem=2,
+             hkx_to_si=lambda value, model: (hkx_to_degree(value[0], model),
+                                             hkx_to_degree(value[1], model)),
+             si_to_hkx=lambda value, model: (degree_to_hkx(value[0], model),
+                                             degree_to_hkx(value[1], model)))
+                                             
+_add_control('angle_limit',
+             eeprom_ram = 'RAM', 
+             address=20, nb_elem=2,
+             hkx_to_si=lambda value, model: (hkx_to_degree(value[0], model),
+                                             hkx_to_degree(value[1], model)),
+             si_to_hkx=lambda value, model: (degree_to_hkx(value[0], model),
+                                             degree_to_hkx(value[1], model)),
+            setter_name='_set_angle_limit')
+
+_add_control('status_error',
+             eeprom_ram = 'RAM', 
+             address=48, length=1,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_status_error)
+
+_add_control('status_detail',
+             eeprom_ram = 'RAM', 
+             address=49, length=1,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_status_detail)
+
+_add_control('torque_enable',
+             eeprom_ram = 'RAM', 
+             address=52, length=1,
+             hkx_to_si=hkx_to_torque_enabled,
+             si_to_hkx=torque_enabled_to_hkx,
+             getter_name='is_torque_enabled',
+             setter_name='_set_torque_enable')
+
+_add_control('LED',
+             eeprom_ram = 'RAM', 
+             address=53, length=1,
+             hkx_to_si=hkx_to_LED,
+             si_to_hkx=LED_to_hkx)
+             
+_add_control('present_voltage',
+             eeprom_ram = 'RAM', 
+             address=54, length=1,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_voltage)
+
+_add_control('present_temperature',
+             eeprom_ram = 'RAM', 
+             address=55, length=1,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_temperature)
+
+_add_control('control_mode',
+             eeprom_ram = 'RAM', 
+             address=56, length=1,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_control_mode,
+             si_to_hkx=control_mode_to_hkx)
+
+
+_add_control('present_position',
+             eeprom_ram = 'RAM', 
+             address=60,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_degree)
+             
+_add_control('present_speed',
+             eeprom_ram = 'RAM', 
+             address=62,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_speed)
+
+_add_control('present_load',
+             eeprom_ram = 'RAM', 
+             address=64,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_load)
+             
+_add_control('goal_position',
+             eeprom_ram = 'RAM', 
+             address=68,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_degree)
+
+_add_control('local_goal_position',
+             eeprom_ram = 'RAM', 
+             address=70,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_degree)
+
+_add_control('local_goal_speed',
+             eeprom_ram = 'RAM', 
+             address=72,
+             access=_HkxAccess.readonly,
+             hkx_to_si=hkx_to_speed)
+             
+_add_control('present_position_speed_load',
+             eeprom_ram = 'RAM',
+             address=60, nb_elem=3,
+             access=_HkxAccess.readonly,
+             hkx_to_si=lambda value, model: (hkx_to_degree(value[0], model),
+                                             hkx_to_speed(value[1], model),
+                                             hkx_to_load(value[2], model)))
+
+_add_control('present_voltage_temperature',
+             eeprom_ram = 'RAM',
+             address=54, nb_elem=2,
+             access=_HkxAccess.readonly,
+             hkx_to_si=lambda value, model: (hkx_to_voltage(value[0], model),
+                                             hkx_to_temperature(value[1], model)))
+

--- a/pypot/herkulex/io/io.py
+++ b/pypot/herkulex/io/io.py
@@ -152,7 +152,6 @@ _add_control('compliance_slope',
              address=12,
              eeprom_ram = 'RAM')
              
-             
 _add_control('torque_limit_EEPROM',
              eeprom_ram = 'EEPROM', 
              address=22,
@@ -180,7 +179,7 @@ _add_control('angle_limit',
                                              hkx_to_degree(value[1], model)),
              si_to_hkx=lambda value, model: (degree_to_hkx(value[0], model),
                                              degree_to_hkx(value[1], model)),
-            setter_name='_set_angle_limit')
+             setter_name='_set_angle_limit')
 
 _add_control('status_error',
              eeprom_ram = 'RAM', 

--- a/pypot/herkulex/motor.py
+++ b/pypot/herkulex/motor.py
@@ -243,7 +243,6 @@ class HkxMotor(Motor):
                 else:
                     self._exec_time = hkx_max_playtime
                     self.moving_speed = abs(self.goal_position - self.present_position) / hkx_max_playtime
-                print('motor %s: goal position: %s | moving.speed: %s | exec time:%s'%(self.name, self.goal_position, self.moving_speed, self._exec_time))
         self._prev_requested_speed = self.moving_speed
         self._prev_requested_position = self.goal_position
 

--- a/pypot/herkulex/motor.py
+++ b/pypot/herkulex/motor.py
@@ -1,0 +1,273 @@
+import numpy
+import logging
+
+import pypot.utils.pypot_time as time
+from pypot.robot.motor import Motor
+from pypot.utils.trajectory import GotoMinJerk
+from pypot.utils.stoppablethread import StoppableLoopThread
+
+from conversion import hkx_max_playtime
+from conversion import hkx_max_speed
+
+logger = logging.getLogger(__name__)
+
+
+class HkxRegister(object):
+    def __init__(self, rw=False):
+        self.rw = rw
+
+    def __get__(self, instance, owner):
+        return instance.__dict__.get(self.label, 0)
+
+    def __set__(self, instance, value):
+        if not self.rw:
+            raise AttributeError("can't set attribute")
+
+        logger.debug("Setting '%s.%s' to %s",
+                     instance.name, self.label, value)
+        instance.__dict__[self.label] = value
+
+
+class HkxOrientedRegister(HkxRegister):
+    def __get__(self, instance, owner):
+        value = HkxRegister.__get__(self, instance, owner)
+        return (value if instance.direct else -value)
+
+    def __set__(self, instance, value):
+        value = value if instance.direct else -value
+        HkxRegister.__set__(self, instance, value)
+
+
+class HkxPositionRegister(HkxOrientedRegister):
+    def __get__(self, instance, owner):
+        value = HkxOrientedRegister.__get__(self, instance, owner)
+        return value - instance.offset
+
+    def __set__(self, instance, value):
+        value = value + instance.offset
+        HkxOrientedRegister.__set__(self, instance, value)
+
+
+class RegisterOwner(type):
+    def __new__(cls, name, bases, attrs):
+        for n, v in attrs.items():
+            if isinstance(v, HkxRegister):
+                v.label = n
+                attrs['registers'].append(n)
+        return super(RegisterOwner, cls).__new__(cls, name, bases, attrs)
+
+
+class HkxMotor(Motor):
+    """ High-level class used to represent and control a generic herkulex motor.
+
+        This class provides all level access to (see :attr:`~pypot.herkulex.motor.HkxMotor.registers` for an exhaustive list):
+            * motor id
+            * motor name
+            * motor model
+            * present position/speed/load
+            * new goal position / execution time for one-shot jog instruction
+            * torque limit
+            * compliant
+            * motor orientation and offset
+            * angle limit
+            * temperature
+            * voltage
+
+        This class represents a generic herkulex motor and you define your own subclass for specific motors.
+
+        Those properties are synchronized with the real motors values thanks to a :class:`~pypot.herkulex.controller.HkxController`.
+
+        """
+    __metaclass__ = RegisterOwner
+
+    registers = Motor.registers + ['registers',
+                                   'goal_speed',
+                                   'compliant', 'safe_compliant',
+                                   'angle_limit']
+
+    id = HkxRegister()
+    name = HkxRegister()
+    model = HkxRegister()
+
+    present_position = HkxPositionRegister() 
+    _goal_position_register = HkxPositionRegister()#read only, the write part is done with _goal_position
+    present_speed = HkxOrientedRegister()
+    present_load = HkxOrientedRegister()
+    torque_limit = HkxRegister(rw=True)
+
+    lower_limit = HkxPositionRegister()
+    upper_limit = HkxPositionRegister()
+    present_voltage = HkxRegister()
+    present_temperature = HkxRegister()
+
+    def __init__(self, id, name=None, model='',
+                 direct=True, offset=0.0,
+                 broken=False):
+        self.__dict__['id'] = id
+
+        name = name if name is not None else 'motor_{}'.format(id)
+        self.__dict__['name'] = name
+
+        self.__dict__['model'] = model
+        self.__dict__['direct'] = direct
+        self.__dict__['offset'] = offset
+
+        self.__dict__['compliant'] = True
+
+        self._safe_compliance = SafeCompliance(self)
+        self.goto_behavior = 'dummy'
+        self.compliant_behavior = 'dummy'
+
+        self._broken = broken
+        self._exec_time = -1.
+        self._goal_position = 0. #used to set goal position (RO register, only changed via jog)
+        self._moving_speed = -1. #simulate a target speed register
+
+    def __repr__(self):
+        return ('<HkxMotor name={self.name} '
+                'id={self.id} '
+                'pos={self.present_position}>').format(self=self)
+
+          
+##################TODO: add speed control
+ 
+    @property
+    def moving_speed(self):
+        return self._moving_speed
+
+    @moving_speed.setter
+    def moving_speed(self, ns):
+        self._moving_speed = min(ns, hkx_max_speed)
+        #setting speed to 0 means max speed (to mimick Dxl)
+        if ns == 0:
+            self._moving_speed = hkx_max_speed
+        #if we are not at goal position, try to reach it
+        if not self._goal_position == self.present_position:
+            self._enforce_speed_logic()
+        else:
+            self._exec_time = -1
+            
+    @property
+    def goal_position(self):
+        return self._goal_position
+
+    @goal_position.setter
+    def goal_position(self, gpos):
+        self._goal_position = gpos
+        #if we have nonzero moving speed, go to the new goal position
+        if self.moving_speed > 0:
+            self._enforce_speed_logic()
+        else:
+            self._exec_time = -1
+
+    #make sure we don't exceed the max playtime when moves triggered by goal position / goal speed changes
+    #this is done by adjusting the moving speed
+    #TODO: improve by splitting the move accross several update cycles instead?
+    def _enforce_speed_logic(self):
+        theoexec = abs(self._goal_position - self.present_position) / self.moving_speed
+        if theoexec <= hkx_max_playtime:
+            self._exec_time = theoexec
+        else:
+            self._exec_time = hkx_max_playtime
+            self._moving_speed = (self._goal_position - self.present_position) / hkx_max_playtime
+      
+    @property
+    def compliant_behavior(self):
+        return self._compliant_behavior
+
+    @compliant_behavior.setter
+    def compliant_behavior(self, value):
+        if value not in ('dummy', 'safe'):
+            raise ValueError('Wrong compliant type! It should be either "dummy" or "safe".')
+
+        if hasattr(self, '_compliant_behavior') and self._compliant_behavior == value:
+            return
+
+        self._compliant_behavior = value
+
+        # Start the safe compliance behavior when the motor should be compliant
+        if value is 'safe' and self.compliant:
+            self._safe_compliance.start()
+
+        if value is 'dummy':
+            use_safe = self._safe_compliance.started
+            if use_safe:
+                self._safe_compliance.stop()
+            self.compliant = self.compliant or use_safe
+
+    @property
+    def compliant(self):
+        return bool(self.__dict__['compliant'])
+
+    @compliant.setter
+    def compliant(self, is_compliant):
+        if self._safe_compliance.started and is_compliant:
+            return
+
+        if self.compliant_behavior == 'dummy':
+            self._set_compliancy(is_compliant)
+
+        elif self.compliant_behavior == 'safe':
+            if is_compliant:
+                self._safe_compliance.start()
+            elif self._safe_compliance.started:
+                self._safe_compliance.stop()
+
+    def _set_compliancy(self, is_compliant):
+        #TODO: check if we need to keep the below test as well for hkx (i.e. jog to current position when switching from compliant to non-compliant)
+        # Change the goal_position only if you switch from compliant to not compliant mode
+        #if not is_compliant and self.compliant:
+        #    self.goal_position = self.present_position
+        self.__dict__['compliant'] = is_compliant
+
+    @property
+    def angle_limit(self):
+        return self.lower_limit, self.upper_limit
+
+    @angle_limit.setter
+    def angle_limit(self, limits):
+        self.lower_limit, self.upper_limit = limits
+
+    @property
+    def goto_behavior(self):
+        return self._default_goto_behavior
+
+    @goto_behavior.setter
+    def goto_behavior(self, value):
+        if value not in ('dummy', 'minjerk'):
+            raise ValueError('Wrong compliant type! It should be either "dummy" or "minjerk".')
+        self._default_goto_behavior = value
+
+    def goto_position(self, position, duration, control=None, wait=False):
+        """ Reach the desired position within the specified duration"""
+        #make sure we don't exceed the max playtime
+        #this is done by adjusting the duration
+        #TODO: improve by splitting the move accross several update cycles instead?
+        duration = min(duration, hkx_max_playtime)
+        #also keep track of the implied moving speed
+        #if the implied speed is 0, we do NOT transform it to the maximum speed
+        self._moving_speed = abs(position - self.present_position) / (duration)
+        if control is None:
+            control = self.goto_behavior
+        #TODO: investigate minjerk through the min PWM register?
+        if control == 'minjerk':
+            pass
+        elif control == 'dummy':
+            self._exec_time = duration
+            self.goal_position = position
+
+            if wait:
+                time.sleep(duration)
+
+class SafeCompliance(StoppableLoopThread):
+    """ This class creates a controller to active compliance only if the current motor position is included in the angle limit, else the compliance is turned off. """
+
+    def __init__(self, motor, frequency=50):
+        StoppableLoopThread.__init__(self, frequency)
+        self.motor = motor
+
+    def update(self):
+        self.motor._set_compliancy((min(self.motor.angle_limit) < self.motor.present_position < max(self.motor.angle_limit)))
+
+    def teardown(self):
+        self.motor._set_compliancy(False)

--- a/pypot/herkulex/protocol.py
+++ b/pypot/herkulex/protocol.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+
+import numpy
+import itertools
+
+from collections import namedtuple
+
+
+HkxBroadcast = 254
+
+
+class HkxInstruction(object):
+    EEP_WRITE = 0x01
+    EEP_READ = 0x02
+    RAM_WRITE = 0x03
+    RAM_READ = 0x04
+    I_JOG = 0x05
+    S_JOG = 0x06
+    STAT = 0x07
+    ROLLBACK = 0x08
+    REBOOT = 0x09
+
+
+# MARK: - Packet Header
+
+class HkxPacketHeader(namedtuple('HkxPacketHeader', ('packet_length', 'id'))):
+    """ This class represents the header of a Hkx Packet.
+
+        They are constructed as follows [0xFF, 0xFF, LENGTH, ID] where:
+            * ID represents the ID of the motor who received (resp. sent) the intruction (resp. status) packet.
+            * LENGTH represents the length of the rest of the packet
+
+        """
+    length = 4
+    marker = bytearray((0xFF, 0xFF))
+
+    @classmethod
+    def from_string(cls, data):
+        header = bytearray(data)
+
+        if len(header) != cls.length or header[:len(cls.marker)] != cls.marker:
+            raise ValueError('try to parse corrupted data ({})'.format(header))
+        
+        return cls(header[2], header[3])
+
+
+# MARK: - Instruction Packet
+
+class HkxInstructionPacket(namedtuple('HkxInstructionPacket',
+                                      ('id', 'instruction', 'parameters'))):
+    """ This class is used to represent a herkulex instruction packet.
+
+        An instruction packet is constructed as follows:
+        [0xFF, 0xFF, SIZE, ID, INSTRUCTION, CHECKSUM1, CHECKSUM2, PARAM 1, PARAM 2, ..., PARAM N]
+
+        """
+    def to_array(self):
+        return bytearray(itertools.chain(HkxPacketHeader.marker,
+                                         (self.size, self.id, self.instruction),
+                                         self.checksums,
+                                         self.parameters
+                                         ))
+
+    def to_string(self):
+        return bytes(self.to_array())
+
+    @property
+    def size(self):
+        return len(self.parameters) + 7
+
+    @property
+    def checksums(self):
+        check1= self.size ^ self.id ^ self.instruction
+        for t in self.parameters:
+            check1 = check1 ^ t
+        check1 = check1 & 0xFE
+        return (check1, (~check1) & 0xFE)
+
+
+class HkxPingPacket(HkxInstructionPacket):
+    """ This class is used to represent ping packet. """
+    def __new__(cls, id):
+        return HkxInstructionPacket.__new__(cls, id, HkxInstruction.STAT, ())
+
+    def __repr__(self):
+        return 'HkxPingPacket(id={})'.format(self.id)
+
+class HkxRollBackPacket(HkxInstructionPacket):
+    """ This class is used to represent reset packet. """
+    def __new__(cls):
+        return HkxInstructionPacket.__new__(cls, HkxBroadcast,
+                                            HkxInstruction.ROLLBACK, (0,0))
+
+
+class HkxReadDataPacket(HkxInstructionPacket):
+    """ This class is used to represent read data packet (to read value) """
+    def __new__(cls, id, eeprom_ram, address, length):
+        instruct = HkxInstruction.RAM_READ
+        if(eeprom_ram) == 'EEPROM':
+            instruct = HkxInstruction.EEP_READ
+        return HkxInstructionPacket.__new__(cls, id,
+                                            instruct,
+                                            (address, length))
+
+    def __repr__(self):
+        return ('HkxReadDataPacket(id={}, '
+                'address={}, total length={}, value={})'.format(self.id,
+                                               self.parameters[0],
+                                               self.parameters[1],
+                                               self.parameters[2:]))
+
+
+class HkxWriteDataPacket(HkxInstructionPacket):
+    """ This class is used to represent write data packet (to write value) """
+    def __new__(cls, id, eeprom_ram, address, length, nb_elem, coded_value):
+        instruct = HkxInstruction.RAM_WRITE
+        if(eeprom_ram) == 'EEPROM':
+            instruct = HkxInstruction.EEP_WRITE
+        return HkxInstructionPacket.__new__(cls, id,
+                                            instruct,
+                                            tuple(itertools.chain((address, length * nb_elem),
+                                                                  coded_value)))
+
+    def __repr__(self):
+        return ('HkxWriteDataPacket(id={}, '
+                'address={}, total length={}, value={})'.format(self.id,
+                                               self.parameters[0],
+                                               self.parameters[1],
+                                               self.parameters[2:]))
+
+class HkxJogPacket(HkxInstructionPacket):
+    """ This class is used to represent jog packets  """
+    def __new__(cls, id, jog_type, coded_value):
+        return HkxInstructionPacket.__new__(cls, id,
+                                            HkxInstruction.I_JOG,
+                                            coded_value)
+
+    def __repr__(self):
+        return ('HkxJogPacket(id={}, '
+                'instruction={}, parameters={})'.format(self.id,
+                                        self.instruction,
+                                        self.parameters[0:]))
+
+
+# MARK: - Status Packet
+class HkxStatusPacket(namedtuple('HkxStatusPacket', ('id', 'instruction', 'parameters', 'error', 'status_detail'))):
+    """ This class is used to represent a herculex status packet.
+
+        A status packet is constructed as follows:
+        [0xFF, 0xFF, SIZE, ID, INSTRUCTION, CHECKSUM1, CHECKSUM2, PARAM 1, PARAM 2, ..., PARAM N, STATUS ERROR, STATUS DETAIL]
+
+        """
+    @classmethod
+    def from_string(cls, data):
+        packet = bytearray(data)
+        header = HkxPacketHeader.from_string(packet[:4])
+        #TODO add checksum test
+        if len(packet) != header.packet_length :
+            raise ValueError('try to parse corrupted data ({})'.format(packet))
+
+        return cls(header.id, packet[4], tuple(packet[9:-2]), packet[-2], packet[-1])
+    
+    def __repr__(self):
+        return ('HkxStatusPacket(id={}, '
+                'instruction={}, parameters={}, error={}, status detail={})'.format(self.id,
+                                        self.instruction,
+                                        self.parameters,
+                                        self.error,
+                                        self.status_detail))

--- a/pypot/robot/config.py
+++ b/pypot/robot/config.py
@@ -39,8 +39,8 @@ def from_config(config, strict=True, possible_ports=None, sync=True):
         :param bool strict: make sure that all ports, motors are availaible.
         :param bool sync: choose if automatically starts the synchronization loops
         :param dictionary possible_ports: dictionary giving, for each manufacturer, a list of ports where the motors should be looked for if not already specified in the config
-        if the port is not specifiec in the config and possible_port is None, then all serial ports can be scanned (possibly causing a mess)
-
+        if the port is not specified in the config and possible_port is None, then all serial ports can be scanned (possibly causing a mess)
+        example of syntax for possible_ports: {'Herkulex' : ('COM4',),'Dynamixel' : ('COM3',)}
         For details on how to write such a configuration dictionnary, you should refer to the section :ref:`config_file`.
 
         """

--- a/pypot/robot/config.py
+++ b/pypot/robot/config.py
@@ -13,6 +13,7 @@ import numpy
 import time
 import json
 import platform
+import glob
 
 #manufacturer-specific stuff
 import pypot.herkulex.io
@@ -359,7 +360,7 @@ def find_port(ids, ioCls, strict=True, poss_ports=None):
     
                     if not strict and founds >= len(ids) / 2:
                         return port
-            except HkxError:
+            except Exception:
                 continue
 
     raise IndexError('No suitable port found for ids {}!'.format(ids))

--- a/pypot/robot/config.py
+++ b/pypot/robot/config.py
@@ -12,6 +12,13 @@ import logging
 import numpy
 import time
 import json
+import platform
+
+#manufacturer-specific stuff
+import pypot.herkulex.io
+import pypot.herkulex.error
+import pypot.herkulex.motor
+import pypot.herkulex.controller
 
 import pypot.dynamixel
 import pypot.dynamixel.io
@@ -25,12 +32,14 @@ from .robot import Robot
 logger = logging.getLogger(__name__)
 
 
-def from_config(config, strict=True, sync=True):
+def from_config(config, strict=True, possible_ports=None, sync=True):
     """ Returns a :class:`~pypot.robot.robot.Robot` instance created from a configuration dictionnary.
 
         :param dict config: robot configuration dictionary
         :param bool strict: make sure that all ports, motors are availaible.
         :param bool sync: choose if automatically starts the synchronization loops
+        :param dictionary possible_ports: dictionary giving, for each manufacturer, a list of ports where the motors should be looked for if not already specified in the config
+        if the port is not specifiec in the config and possible_port is None, then all serial ports can be scanned (possibly causing a mess)
 
         For details on how to write such a configuration dictionnary, you should refer to the section :ref:`config_file`.
 
@@ -39,27 +48,53 @@ def from_config(config, strict=True, sync=True):
 
     alias = config['motorgroups']
 
-    # Instatiate the different motor controllers
+    # Instantiate the different motor controllers
     controllers = []
     for c_name, c_params in config['controllers'].items():
         motor_names = sum([_motor_extractor(alias, name)
                            for name in c_params['attached_motors']], [])
+        #autodetect the manufacturer based on motor type
+        manufacturer = None
+        if all(config['motors'][mn]['type'] in pypot.dynamixel.conversion.dynamixelModels.values() for mn in motor_names):
+            manufacturer = 'Dynamixel'
+        elif all(config['motors'][mn]['type'] in pypot.herkulex.conversion.herkulexModels.values() for mn in motor_names):
+            manufacturer = 'Herkulex'
+        #set manufacturer-specific functions and classes
+        if manufacturer == 'Herkulex':
+            function_motor_from_confignode = hkx_motor_from_confignode
+            ioCls=pypot.herkulex.io.HkxIO
+            controllerCls = pypot.herkulex.BaseHkxController
+            handlerCls = pypot.herkulex.HkxBaseErrorHandler
+        elif manufacturer == 'Dynamixel':
+            function_motor_from_confignode = dxl_motor_from_confignode
+            ioCls= (pypot.dynamixel.io.Dxl320IO
+                if 'protocol' in c_params and c_params['protocol'] == 2
+                else pypot.dynamixel.io.DxlIO)
+            controllerCls = pypot.dynamixel.BaseDxlController
+            handlerCls = pypot.dynamixel.BaseErrorHandler
+        else:
+            raise Exception('Unable to recognize a single manufacturer for motors %s in controller %s' %(motor_names, c_name))
 
-        attached_motors = [motor_from_confignode(config, name)
+        attached_motors = [function_motor_from_confignode(config, name)
                            for name in motor_names]
 
         # at least one of the motor is set as broken
         if [m for m in attached_motors if m._broken]:
             strict = False
-
+        poss_ports = None
+        #if the port is to be auto-detected check if it should only be among certain ports 
+        if c_params['port'] == 'auto':
+            if possible_ports != None:
+                if manufacturer in possible_ports:
+                    poss_ports = possible_ports[manufacturer]
         attached_ids = [m.id for m in attached_motors]
-        dxl_io = dxl_io_from_confignode(config, c_params, attached_ids, strict)
+        io = io_from_confignode(config, c_params, attached_ids, strict, ioCls, poss_ports, handlerCls)
 
-        check_motor_limits(config, dxl_io, motor_names)
+        check_motor_limits(config, io, motor_names)
 
-        c = pypot.dynamixel.controller.BaseDxlController(dxl_io, attached_motors)
+        c = controllerCls(io, attached_motors)
         logger.info('Instantiating controller on %s with motors %s',
-                    dxl_io.port, motor_names,
+                    io.port, motor_names,
                     extra={'config': config})
 
         controllers.append(c)
@@ -72,8 +107,8 @@ def from_config(config, strict=True, sync=True):
 
     return robot
 
-
-def motor_from_confignode(config, motor_name):
+#just changed the name by adding 'dxl_' in front to make it clearly dxl-specific
+def dxl_motor_from_confignode(config, motor_name):
     params = config['motors'][motor_name]
 
     type = params['type']
@@ -97,38 +132,48 @@ def motor_from_confignode(config, motor_name):
 
     return m
 
+#new function for herkulex
+def hkx_motor_from_confignode(config, motor_name):
+    params = config['motors'][motor_name]
+    m = pypot.herkulex.motor.HkxMotor(id=params['id'],
+                 name=motor_name,
+                 model=params['type'],
+                 direct=True if params['orientation'] == 'direct' else False,
+                 offset=params['offset'],
+                 broken='broken' in params)
 
-def dxl_io_from_confignode(config, c_params, ids, strict):
+    logger.info("Instantiating motor '%s' id=%d direct=%s offset=%s",
+                m.name, m.id, m.direct, m.offset,
+                extra={'config': config})
+
+    return m
+
+#'universal' version of the original function (including for error handler)
+def io_from_confignode(config, c_params, ids, strict, ioCls, poss_ports, handlerCls):
     port = c_params['port']
 
     if port == 'auto':
-        port = pypot.dynamixel.find_port(ids, strict)
+        port = find_port(ids, ioCls, strict, poss_ports)
         logger.info('Found port {} for ids {}'.format(port, ids))
 
-    handler = pypot.dynamixel.error.BaseErrorHandler
-
-    DxlIOCls = (pypot.dynamixel.io.Dxl320IO
-                if 'protocol' in c_params and c_params['protocol'] == 2
-                else pypot.dynamixel.io.DxlIO)
-
-    dxl_io = DxlIOCls(port=port,
+    io = ioCls(port=port,
                       use_sync_read=c_params['sync_read'],
-                      error_handler_cls=handler)
+                      error_handler_cls=handlerCls)
 
-    found_ids = dxl_io.scan(ids)
+    found_ids = io.scan(ids)
     if ids != found_ids:
         missing_ids = tuple(set(ids) - set(found_ids))
         msg = 'Could not find the motors {} on bus {}.'.format(missing_ids,
-                                                               dxl_io.port)
+                                                               io.port)
         logger.warning(msg)
 
         if strict:
-            raise pypot.dynamixel.io.DxlError(msg)
+            raise Exception(msg)
 
-    return dxl_io
+    return io
 
 
-def check_motor_limits(config, dxl_io, motor_names):
+def check_motor_limits(config, io, motor_names):
     changed_angle_limits = {}
 
     for name in motor_names:
@@ -136,7 +181,7 @@ def check_motor_limits(config, dxl_io, motor_names):
         id = m['id']
 
         try:
-            old_limits = dxl_io.get_angle_limit((id, ))[0]
+            old_limits = io.get_angle_limit((id, ))[0]
         except IndexError:  # probably a broken motor so we just skip
             continue
         new_limits = m['angle_limit']
@@ -149,7 +194,7 @@ def check_motor_limits(config, dxl_io, motor_names):
             changed_angle_limits[id] = new_limits
 
     if changed_angle_limits:
-        dxl_io.set_angle_limit(changed_angle_limits)
+        io.set_angle_limit(changed_angle_limits)
         time.sleep(1)
 
 
@@ -187,8 +232,8 @@ def make_alias(config, robot):
                     alias_name, [motor.name for motor in motors],
                     extra={'config': config})
 
-
-def from_json(json_file, sync=True):
+#'universal' version of the original function to support mixed motor manufacturers, even within the same robot (but no mix within a controller)
+def from_json(json_file, possible_ports = None, sync=True):
     """ Returns a :class:`~pypot.robot.robot.Robot` instance created from a JSON configuration file.
 
     For details on how to write such a configuration file, you should refer to the section :ref:`config_file`.
@@ -197,7 +242,7 @@ def from_json(json_file, sync=True):
     with open(json_file) as f:
         config = json.load(f)
 
-    return from_config(config, sync=sync)
+    return from_config(config, possible_ports=possible_ports, sync=sync)
 
 
 def _motor_extractor(alias, name):
@@ -267,3 +312,54 @@ ergo_robot_config = {
         }
     }
 }
+
+#just taken from pypot/dynamixel/__init__.py
+def get_available_ports():
+    """ Tries to find the available usb2serial port on your system. """
+    if platform.system() == 'Darwin':
+        return glob.glob('/dev/tty.usb*')
+
+    elif platform.system() == 'Linux':
+        return glob.glob('/dev/ttyACM*') + glob.glob('/dev/ttyUSB*')
+
+    elif platform.system() == 'Windows':
+        import _winreg
+        import itertools
+
+        ports = []
+        path = 'HARDWARE\\DEVICEMAP\\SERIALCOMM'
+        key = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, path)
+
+        for i in itertools.count():
+            try:
+                ports.append(str(_winreg.EnumValue(key, i)[1]))
+            except WindowsError:
+                return ports
+
+    return []
+
+#taken from dynamixel __init__.py and extended to support mixed motor manufacturers
+def find_port(ids, ioCls, strict=True, poss_ports=None):
+    """ Find the port with the specified attached motor ids.
+
+        :param list ids: list of motor ids to find
+        :param bool strict: specify if all ids should be find (when set to False, only half motor must be found)
+        :param poss_ports: used to restrict the search
+        .. warning:: If two (or more) ports are attached to the same list of motor ids the first match will be returned.
+
+    """
+    for port in get_available_ports():
+        if poss_ports == None or port in poss_ports:
+            try:
+                with ioCls(port) as io_sc:
+                    founds = len(io_sc.scan(ids))
+    
+                    if strict and founds == len(ids):
+                        return port
+    
+                    if not strict and founds >= len(ids) / 2:
+                        return port
+            except HkxError:
+                continue
+
+    raise IndexError('No suitable port found for ids {}!'.format(ids))

--- a/samples/herkulex_test/cross_code_test_v1.py
+++ b/samples/herkulex_test/cross_code_test_v1.py
@@ -1,0 +1,26 @@
+
+import time
+import pypot.robot
+import numpy
+import pypot.primitive
+
+eligible_ports = {'Herkulex' : ('COM4',),'Dynamixel' : ('COM3',)}
+crossfile = 'cross_config_v1.json'
+
+class DancePrimitive(pypot.primitive.Primitive):
+    def run(self, amp=30, freq=0.5):
+        while self.elapsed_time < 5:
+            x = amp * numpy.sin(2 * numpy.pi * freq * self.elapsed_time)
+            for m in self.robot.motors:
+                m.goto_position(x,0.02)
+            time.sleep(0.02)
+
+if __name__ == '__main__':
+    test_robot=pypot.robot.from_json(crossfile, eligible_ports)
+    test_robot.compliant = False
+    dance = DancePrimitive(test_robot)
+    dance.start()
+    dance.stop()
+    test_robot.compliant = True
+    test_robot.close()
+    print('done!')

--- a/samples/herkulex_test/cross_config_v1.json
+++ b/samples/herkulex_test/cross_config_v1.json
@@ -1,0 +1,117 @@
+{
+  "controllers": {
+	"hkx_controller": {
+      "sync_read": false,
+      "attached_motors": [
+        "leg1",
+        "leg2"
+      ],
+      "port": "auto"
+    },
+    "dxl_controller": {
+      "sync_read": false,
+      "attached_motors": [
+        "pullers"
+      ],
+      "port": "auto"
+    }
+  },
+  "motorgroups": {
+    "leg1": [
+      "leg1_base",
+	 "leg1_joint1",
+	 "leg1_joint2"
+    ],
+    "leg2": [
+      "leg2_base",
+	 "leg2_joint1",
+	 "leg2_joint2"
+    ],
+    "pullers": [
+      "puller1",
+	 "puller2"
+    ]
+  },
+  "motors": {
+    "puller1": {
+      "offset": 0.0,
+      "type": "AX-12",
+      "id": 1,
+      "angle_limit": [
+        -100.0,
+        100.0
+      ],
+      "orientation": "direct"
+    },
+    "puller2": {
+      "offset": 0.0,
+      "type": "AX-12",
+      "id": 2,
+      "angle_limit": [
+        -100.0,
+        100.0
+      ],
+      "orientation": "direct"
+    },
+    "leg1_base": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 1,
+      "angle_limit": [
+        -100.0,
+        100.0
+      ],
+      "orientation": "direct"
+    },
+    "leg1_joint1": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 2,
+      "angle_limit": [
+        -100.0,
+        100.0
+      ],
+      "orientation": "direct"
+    },
+    "leg1_joint2": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 3,
+      "angle_limit": [
+        -100.0,
+        100.0
+      ],
+      "orientation": "direct"
+    },
+    "leg2_base": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 4,
+      "angle_limit": [
+        -100.0,
+        100.0
+      ],
+      "orientation": "direct"
+    },
+    "leg2_joint1": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 5,
+      "angle_limit": [
+        -100.0,
+        100.0
+      ],
+      "orientation": "direct"
+    },
+    "leg2_joint2": {
+      "offset": 0.0,
+      "type": "DRS-0101",
+      "id": 6,
+      "angle_limit": [
+        -100.0,
+        100.0
+      ],
+      "orientation": "direct"
+    }
+  }
+}


### PR DESCRIPTION
The Herkulex code follows the same structure as the one for Dynamixel servos, but is completely independent.

Only the 'robot/config.py' needs to be changed out of the existing code.

Servo / OS setup:
    - Servos baudrates should be set to 115,200 (e.g. with HerkulexManager)
    - It is also strongly advised to reduce the FTDI latency timer to 1ms (vs 16ms by default) in the port settings of your OS

Main outstanding points:
    - tweak the mechansim that sends / receives packets (e.g. via shared queue ?) in order to reduce latency with the FTDI USB-to-serial port. At the moment up to 6 servos can run at 50Hz. 
    - improve handling of long playtimes  (>  2.8s)
    - add the equivalent of the "goal_speed" function
    - and quite a few things here and there - this is still WIP!
