### PR TITLE
Add auto of sync_read

### DIFF
--- a/pypot/dynamixel/__init__.py
+++ b/pypot/dynamixel/__init__.py
@@ -54,7 +54,7 @@ def get_available_ports(only_free=False):
     return ports
 
 
-def get_port_vendor_info(port):
+def get_port_vendor_info(port=None):
     """ Return vendor informations of the serial port specified.
         It may depends on the Operating System.
 
@@ -67,7 +67,10 @@ def get_port_vendor_info(port):
 
     port_info_list = serial.tools.list_ports.comports()
     port_info_dict = dict((x[0], (x[1], x[2])) for x in port_info_list[:])
-    return port_info_dict[port]
+    if port is not None:
+        return port_info_dict[port]
+    else:
+        return port_info_dict
 
 
 def find_port(ids, strict=True):

--- a/pypot/dynamixel/__init__.py
+++ b/pypot/dynamixel/__init__.py
@@ -64,11 +64,7 @@ def get_port_vendor_info(port=None):
         Out[2]: 'USB VID:PID=0403:6001 SNR=A7005LKE' """
 
     port_info_dict = dict((x[0], x[2]) for x in serial.tools.list_ports.comports())
-    try:
-        return port_info_dict[port] if port is not None else port_info_dict
-    except KeyError:
-        logger.error('port {} is not found by serial.tools.list_ports.comports()'.format(port))
-        return ''
+    return port_info_dict[port] if port is not None else port_info_dict
 
 
 def find_port(ids, strict=True):

--- a/pypot/dynamixel/__init__.py
+++ b/pypot/dynamixel/__init__.py
@@ -55,8 +55,11 @@ def get_available_ports(only_free=False):
 
 
 def get_port_vendor_info(port=None):
-    """ Return vendor informations of the serial port specified.
+    """ Return vendor informations of a usb2serial device.
         It may depends on the Operating System.
+        :param string port: port of the usb2serial device
+
+        :Example:
 
         Result with a USB2Dynamixel on Linux:
         In [1]: import pypot.dynamixel

--- a/pypot/dynamixel/__init__.py
+++ b/pypot/dynamixel/__init__.py
@@ -3,6 +3,8 @@ import platform
 import glob
 import logging
 
+import serial.tools.list_ports
+
 
 from .io import DxlIO, Dxl320IO, DxlError
 from .error import BaseErrorHandler
@@ -50,6 +52,22 @@ def get_available_ports(only_free=False):
         ports = list(set(ports) - set(DxlIO.get_used_ports()))
 
     return ports
+
+
+def get_port_vendor_info(port):
+    """ Return vendor informations of the serial port specified.
+        It may depends on the Operating System.
+
+        Result with a USB2Dynamixel on Linux:
+        In [1]: import pypot.dynamixel
+        In [2]: pypot.dynamixel.get_port_vendor_info('/dev/ttyUSB0')
+        Out[2]:
+        ('Future Technology Devices International, Ltd FT232 USB-Serial (UART) IC ',
+         'USB VID:PID=0403:6001 SNR=A7005LKE') """
+
+    port_info_list = serial.tools.list_ports.comports()
+    port_info_dict = dict((x[0], (x[1], x[2])) for x in port_info_list[:])
+    return port_info_dict[port]
 
 
 def find_port(ids, strict=True):

--- a/pypot/dynamixel/__init__.py
+++ b/pypot/dynamixel/__init__.py
@@ -61,16 +61,14 @@ def get_port_vendor_info(port=None):
         Result with a USB2Dynamixel on Linux:
         In [1]: import pypot.dynamixel
         In [2]: pypot.dynamixel.get_port_vendor_info('/dev/ttyUSB0')
-        Out[2]:
-        ('Future Technology Devices International, Ltd FT232 USB-Serial (UART) IC ',
-         'USB VID:PID=0403:6001 SNR=A7005LKE') """
+        Out[2]: 'USB VID:PID=0403:6001 SNR=A7005LKE' """
 
-    port_info_list = serial.tools.list_ports.comports()
-    port_info_dict = dict((x[0], (x[1], x[2])) for x in port_info_list[:])
-    if port is not None:
-        return port_info_dict[port]
-    else:
-        return port_info_dict
+    port_info_dict = dict((x[0], x[2]) for x in serial.tools.list_ports.comports())
+    try:
+        return port_info_dict[port] if port is not None else port_info_dict
+    except KeyError:
+        logger.error('port {} is not found by serial.tools.list_ports.comports()'.format(port))
+        return ''
 
 
 def find_port(ids, strict=True):

--- a/pypot/robot/config.py
+++ b/pypot/robot/config.py
@@ -142,6 +142,7 @@ def dxl_io_from_confignode(config, c_params, ids, strict):
         vendor_pid = pypot.dynamixel.get_port_vendor_info(port)
         sync_read = ('PID=0403:6001' in vendor_pid and c_params['protocol'] == 2 or
                      'PID=16d0:06a7' in vendor_pid)
+        logger.info('sync_read is {}. Vendor pid = {}'.format(sync_read, vendor_pid))
     handler = pypot.dynamixel.error.BaseErrorHandler
 
     DxlIOCls = (pypot.dynamixel.io.Dxl320IO

--- a/pypot/robot/config.py
+++ b/pypot/robot/config.py
@@ -137,12 +137,11 @@ def dxl_io_from_confignode(config, c_params, ids, strict):
     sync_read = c_params['sync_read']
 
     if sync_read == 'auto':
-        # USB VID:PID=0403:6001 is specific to USB2DYNAMIXEL
-        if '0403:6001' in pypot.dynamixel.get_port_vendor_info(port)[1]:
-            sync_read = False
-        else:
-            sync_read = True
-
+        # USB Vendor Product ID "VID:PID=0403:6001" for USB2Dynamixel
+        # USB Vendor Product ID "VID:PID=16d0:06a7" for USBAX
+        vendor_pid = pypot.dynamixel.get_port_vendor_info(port)
+        sync_read = ('PID=0403:6001' in vendor_pid and c_params['protocol'] == 2
+                     or 'PID=16d0:06a7' in vendor_pid)
     handler = pypot.dynamixel.error.BaseErrorHandler
 
     DxlIOCls = (pypot.dynamixel.io.Dxl320IO

--- a/pypot/robot/config.py
+++ b/pypot/robot/config.py
@@ -134,6 +134,15 @@ def dxl_io_from_confignode(config, c_params, ids, strict):
         port = pypot.dynamixel.find_port(ids, strict)
         logger.info('Found port {} for ids {}'.format(port, ids))
 
+    sync_read = c_params['sync_read']
+
+    if sync_read == 'auto':
+        # USB VID:PID=0403:6001 is specific to USB2DYNAMIXEL
+        if '0403:6001' in pypot.dynamixel.get_port_vendor_info(port)[1]:
+            sync_read = False
+        else:
+            sync_read = True
+
     handler = pypot.dynamixel.error.BaseErrorHandler
 
     DxlIOCls = (pypot.dynamixel.io.Dxl320IO
@@ -141,7 +150,7 @@ def dxl_io_from_confignode(config, c_params, ids, strict):
                 else pypot.dynamixel.io.DxlIO)
 
     dxl_io = DxlIOCls(port=port,
-                      use_sync_read=c_params['sync_read'],
+                      use_sync_read=sync_read,
                       error_handler_cls=handler)
 
     found_ids = dxl_io.scan(ids)

--- a/pypot/robot/config.py
+++ b/pypot/robot/config.py
@@ -143,6 +143,7 @@ def dxl_io_from_confignode(config, c_params, ids, strict):
         sync_read = ('PID=0403:6001' in vendor_pid and c_params['protocol'] == 2 or
                      'PID=16d0:06a7' in vendor_pid)
         logger.info('sync_read is {}. Vendor pid = {}'.format(sync_read, vendor_pid))
+
     handler = pypot.dynamixel.error.BaseErrorHandler
 
     DxlIOCls = (pypot.dynamixel.io.Dxl320IO

--- a/pypot/robot/config.py
+++ b/pypot/robot/config.py
@@ -140,8 +140,8 @@ def dxl_io_from_confignode(config, c_params, ids, strict):
         # USB Vendor Product ID "VID:PID=0403:6001" for USB2Dynamixel
         # USB Vendor Product ID "VID:PID=16d0:06a7" for USBAX
         vendor_pid = pypot.dynamixel.get_port_vendor_info(port)
-        sync_read = ('PID=0403:6001' in vendor_pid and c_params['protocol'] == 2
-                     or 'PID=16d0:06a7' in vendor_pid)
+        sync_read = ('PID=0403:6001' in vendor_pid and c_params['protocol'] == 2 or
+                     'PID=16d0:06a7' in vendor_pid)
     handler = pypot.dynamixel.error.BaseErrorHandler
 
     DxlIOCls = (pypot.dynamixel.io.Dxl320IO


### PR DESCRIPTION
sync_read has to be manually changed from True to False if an USB2Dynamixel is used.  
This pull request check the vendor id of the USB to serial device to guess if it is a USB2AX or a USB2Dynamixel.