### PR TITLE
update inject lua code for py3 compatibility

### DIFF
--- a/pypot/vrep/io.py
+++ b/pypot/vrep/io.py
@@ -264,7 +264,7 @@ class VrepIO(AbstractIO):
 
     def _inject_lua_code(self, lua_code):
         """ Sends raw lua code and evaluate it wihtout any checking! """
-        msg = (ctypes.c_ubyte * len(lua_code)).from_buffer_copy(lua_code)
+        msg = (ctypes.c_ubyte * len(lua_code)).from_buffer_copy(lua_code.encode())
         self.call_remote_api('simxWriteStringStream', 'my_lua_code', msg)
 
     def call_remote_api(self, func_name, *args, **kwargs):


### PR DESCRIPTION
Encode the lua message to avoid the method .from_buffer_copy() to break with python 3.x