### PR TITLE
Prevent from installing enum34 on Python 3.4+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,18 @@ extra = {}
 if sys.version_info >= (3,):
     extra['use_2to3'] = True
 
+install_requires = ['numpy',
+                    'pyserial>2.6',
+                    'scipy']
+
+if sys.version_info < (3, 4):
+    install_requires.append('enum34')
+
 setup(name='pypot',
       version=version(),
       packages=find_packages(),
 
-      install_requires=['numpy', 'pyserial>2.6', 'enum34', 'scipy'],
+      install_requires=install_requires,
 
       extras_require={
           'tools': [],  # Extras require: PyQt4 (not a PyPi packet)


### PR DESCRIPTION
Fix #118.