### PR TITLE
Improve run() of pypot APIs for poppy-simu

### DIFF
--- a/pypot/server/httpserver.py
+++ b/pypot/server/httpserver.py
@@ -1,4 +1,5 @@
 import json
+import SocketServer
 import numpy
 import bottle
 from bottle import response
@@ -38,7 +39,8 @@ class EnableCors(object):
             # set CORS headers
             response.headers['Access-Control-Allow-Origin'] = self.origin
             response.headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, OPTIONS'
-            response.headers['Access-Control-Allow-Headers'] = 'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token'
+            response.headers[
+                'Access-Control-Allow-Headers'] = 'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token'
 
             if bottle.request.method != 'OPTIONS':
                 # actual request; reply with the actual response
@@ -55,7 +57,7 @@ class HTTPRobotServer(AbstractServer):
 
      """
 
-    def __init__(self, robot, host, port, cross_domain_origin='*', quiet=True):
+    def __init__(self, robot, host='0.0.0.0', port='8080', cross_domain_origin='*', quiet=True):
         AbstractServer.__init__(self, robot, host, port)
         self.quiet = quiet
         self.app = bottle.Bottle()
@@ -218,12 +220,23 @@ class HTTPRobotServer(AbstractServer):
 
             return registers_motors
 
-
     def run(self, quiet=None, server='tornado'):
         """ Start the bottle server, run forever. """
         if quiet is None:
             quiet = self.quiet
-        bottle.run(self.app,
-                   host=self.host, port=self.port,
-                   quiet=quiet,
-                   server=server)
+        try:
+            bottle.run(self.app,
+                       host=self.host, port=self.port,
+                       quiet=quiet,
+                       server=server)    
+        except RuntimeError as e:
+            # If you are calling tornado inside tornado (Jupyter notebook)
+            # you got a RuntimeError but everythong works fine
+            if "IOLoop" in e.message:
+                logger.info("Tornado RuntimeError {}".format(e.message))
+                pass
+        except SocketServer.socket.error as e:
+            if e.args[0] != 48:
+                logger.warning(
+                    """The webserver port {} is already used.\n
+                    The HTTPServer is maybe already run or another software use this port.""".format(self.port))

--- a/pypot/server/httpserver.py
+++ b/pypot/server/httpserver.py
@@ -1,5 +1,6 @@
 import json
-import SocketServer
+import socket
+import errno
 import numpy
 import bottle
 from bottle import response
@@ -234,8 +235,10 @@ class HTTPRobotServer(AbstractServer):
             if "IOLoop" in e.message:
                 logger.info("Tornado RuntimeError {}".format(e.message))
                 pass
-        except SocketServer.socket.error as e:
-            if e.args[0] != 48:
-                logger.warning(
-                    """The webserver port {} is already used.\n
-                    The HTTPServer is maybe already run or another software use this port.""".format(self.port))
+        except socket.error as serr:
+            # Re raise the socket error if not "[Errno 98] Address already in use"
+            if serr.errno != errno.EADDRINUSE:
+                raise serr
+            else:
+                logger.warning("""The webserver port {} is already used.
+The HttpRobotServer is maybe already run or another software use this port.""".format(self.port))

--- a/pypot/server/httpserver.py
+++ b/pypot/server/httpserver.py
@@ -39,8 +39,7 @@ class EnableCors(object):
             # set CORS headers
             response.headers['Access-Control-Allow-Origin'] = self.origin
             response.headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, OPTIONS'
-            response.headers[
-                'Access-Control-Allow-Headers'] = 'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token'
+            response.headers['Access-Control-Allow-Headers'] = 'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token'
 
             if bottle.request.method != 'OPTIONS':
                 # actual request; reply with the actual response

--- a/pypot/server/snap.py
+++ b/pypot/server/snap.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import SocketServer
 import bottle
 import socket
 import re
@@ -58,7 +59,7 @@ def set_snap_server_variables(host, port, snap_extension='.xml', path=None):
 
 class SnapRobotServer(AbstractServer):
 
-    def __init__(self, robot, host, port, quiet=True):
+    def __init__(self, robot, host='0.0.0.0', port='6969', quiet=True):
         AbstractServer.__init__(self, robot, host, port)
         self.quiet = quiet
         self.app = bottle.Bottle()
@@ -77,7 +78,6 @@ class SnapRobotServer(AbstractServer):
             shutil.copyfile(xml_file, dst)
 
         set_snap_server_variables(find_local_ip(), port, path=get_snap_user_projects_directory())
-
         @self.app.get('/motors/<alias>')
         def get_motors(alias):
             return '/'.join(rr.get_motors_list(alias))
@@ -287,5 +287,23 @@ class SnapRobotServer(AbstractServer):
             detected = rr.robot.marker_detector.markers
             return str(any([m.id in markers[marker] for m in detected]))
 
-    def run(self):
-        bottle.run(self.app, host=self.host, port=self.port, quiet=self.quiet)
+    def run(self, quiet=None, server='tornado'):
+        """ Start the bottle server, run forever. """
+        if quiet is None:
+            quiet = self.quiet
+        try:
+            bottle.run(self.app,
+                       host=self.host, port=self.port,
+                       quiet=quiet,
+                       server=server)    
+        except RuntimeError as e:
+            # If you are calling tornado inside tornado (Jupyter notebook)
+            # you got a RuntimeError but everythong works fine
+            if "IOLoop" in e.message:
+                logger.info("Tornado RuntimeError {}".format(e.message))
+                pass
+        except SocketServer.socket.error as e:
+            if e.args[0] != 48:
+                logger.warning(
+                    """The webserver port {} is already used.\n
+                    The SnapRobotServer is maybe already run or another software use this port.""".format(self.port))

--- a/pypot/server/snap.py
+++ b/pypot/server/snap.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import SocketServer
+import cgi
 import bottle
 import socket
 import re
@@ -78,6 +79,10 @@ class SnapRobotServer(AbstractServer):
             shutil.copyfile(xml_file, dst)
 
         set_snap_server_variables(find_local_ip(), port, path=get_snap_user_projects_directory())
+        @self.app.get('/')
+        def get_sitemap():
+            return '</br>'.join([cgi.escape(r.rule.format()) for r in self.app.routes])
+
         @self.app.get('/motors/<alias>')
         def get_motors(alias):
             return '/'.join(rr.get_motors_list(alias))


### PR DESCRIPTION
* catch the IOError if a server is already run
* hide the tornado error if we are calling it from jupyter notebook

I hesitated to make the APIs singleton, but I just make a warning log when a user run() a previously run server.