### PR TITLE
Fix find_host_ip

### DIFF
--- a/pypot/server/snap.py
+++ b/pypot/server/snap.py
@@ -46,6 +46,7 @@ def find_host_ip(host=None):
         # If the above method fails (depending on the system)
         # Tries to ping google DNS instead
         with closing(socket.socket()) as s:
+            s.settimeout(1)
             s.connect(('8.8.8.8', 53))
             return s.getsockname()[0]
 

--- a/pypot/server/snap.py
+++ b/pypot/server/snap.py
@@ -32,6 +32,8 @@ def find_host_ip(host=None):
         if host is None:
             host = socket.gethostname()
 
+        if 'local' not in host:
+            host += '.local'
         ips = [ip for ip in socket.gethostbyname_ex(host)[2]
                if not ip.startswith('127.')]
         if len(ips):

--- a/pypot/server/snap.py
+++ b/pypot/server/snap.py
@@ -34,10 +34,14 @@ def find_host_ip(host=None):
 
         if 'local' not in host:
             host += '.local'
-        ips = [ip for ip in socket.gethostbyname_ex(host)[2]
-               if not ip.startswith('127.')]
-        if len(ips):
-            return ips[0]
+
+        try:
+            ips = [ip for ip in socket.gethostbyname_ex(host)[2]
+                   if not ip.startswith('127.')]
+            if len(ips):
+                return ips[0]
+        except socket.gaierror:
+            pass
 
         # If the above method fails (depending on the system)
         # Tries to ping google DNS instead


### PR DESCRIPTION
`socket.gethostbyname_ex('poppy')` will always return 127.0.0.1, but `socket.gethostbyname_ex('poppy.local')` will return the local IPv4 (10.x.x.x or 192.168.x.x).

This solve the IP resolution when there is no network access, and for some network configuration such as issue #169 

@pierre-rouanet I let you check and merge!