### PR TITLE
Dynamically modify host input of "set $robot host" Snap block

### DIFF
--- a/pypot/server/snap.py
+++ b/pypot/server/snap.py
@@ -79,13 +79,13 @@ def set_snap_server_variables(host, port, snap_extension='.xml', path=None):
             xml = xf.read()
         # Change host variable
         xml = re.sub(r'''<variable name="host"><l>[\s\S]*?<\/l><\/variable>''',
-                    '''<variable name="host"><l>{}</l></variable>'''.format(host), xml)
+                     '''<variable name="host"><l>{}</l></variable>'''.format(host), xml)
         # Change host argument of "set $robot host"
         xml = re.sub(r'''<custom-block s="set \$robot host to \%s"><l>[\s\S]*?<\/l>''',
-                    '''<custom-block s="set $robot host to %s"><l>{}</l>'''.format(host), xml)
+                     '''<custom-block s="set $robot host to %s"><l>{}</l>'''.format(host), xml)
         # Change port variable
         xml = re.sub(r'''<variable name="port"><l>[\s\S]*?<\/l><\/variable>''',
-                    '''<variable name="port"><l>{}</l></variable>'''.format(port), xml)
+                     '''<variable name="port"><l>{}</l></variable>'''.format(port), xml)
 
         with open(filename, 'w') as xf:
             xf.write(xml)

--- a/pypot/server/snap.py
+++ b/pypot/server/snap.py
@@ -77,11 +77,17 @@ def set_snap_server_variables(host, port, snap_extension='.xml', path=None):
     for filename in xml_files:
         with open(filename, 'r') as xf:
             xml = xf.read()
+        # Change host variable
+        xml = re.sub(r'''<variable name="host"><l>[\s\S]*?<\/l><\/variable>''',
+                    '''<variable name="host"><l>{}</l></variable>'''.format(host), xml)
+        # Change host argument of "set $robot host"
+        xml = re.sub(r'''<custom-block s="set \$robot host to \%s"><l>[\s\S]*?<\/l>''',
+                    '''<custom-block s="set $robot host to %s"><l>{}</l>'''.format(host), xml)
+        # Change port variable
+        xml = re.sub(r'''<variable name="port"><l>[\s\S]*?<\/l><\/variable>''',
+                    '''<variable name="port"><l>{}</l></variable>'''.format(port), xml)
+
         with open(filename, 'w') as xf:
-            xml = re.sub(r'''<variable name="host"><l>[\s\S]*?<\/l><\/variable>''',
-                         '''<variable name="host"><l>{}</l></variable>'''.format(host), xml)
-            xml = re.sub(r'''<variable name="port"><l>[\s\S]*?<\/l><\/variable>''',
-                         '''<variable name="port"><l>{}</l></variable>'''.format(port), xml)
             xf.write(xml)
     os.chdir(localdir)
 


### PR DESCRIPTION
The *host* variable was modified at startup, but not the input of "set $tobot host"
![snap](https://cloud.githubusercontent.com/assets/3891499/15353628/52dd1594-1cea-11e6-831f-c37aa95aa5d1.png).

