### PR TITLE
Add proper cache header on HTTP servers

### DIFF
--- a/pypot/server/httpserver.py
+++ b/pypot/server/httpserver.py
@@ -58,9 +58,14 @@ class CacheBuster(object):
     """Add response headers to disable cache"""
 
     name = 'cache_buster'
+    api = 2
 
     def apply(self, fn, context):
-        response.set_header('Cache-control', 'no-store')
+        def _ext(*args, **kwargs):
+            response.set_header('Cache-control', 'no-store')
+            return fn(*args, **kwargs)
+
+        return _ext
 
 
 class HTTPRobotServer(AbstractServer):

--- a/pypot/server/httpserver.py
+++ b/pypot/server/httpserver.py
@@ -43,15 +43,24 @@ class EnableCors(object):
     def apply(self, fn, context):
         def _enable_cors(*args, **kwargs):
             # set CORS headers
-            response.headers['Access-Control-Allow-Origin'] = self.origin
-            response.headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, OPTIONS'
-            response.headers['Access-Control-Allow-Headers'] = 'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token'
+            response.set_header('Access-Control-Allow-Origin', self.origin)
+            response.set_header('Access-Control-Allow-Methods', 'GET, POST, PUT, OPTIONS')
+            response.set_header('Access-Control-Allow-Headers', 'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token')
 
             if bottle.request.method != 'OPTIONS':
                 # actual request; reply with the actual response
                 return fn(*args, **kwargs)
 
         return _enable_cors
+
+
+class CacheBuster(object):
+    """Add response headers to disable cache"""
+
+    name = 'cache_buster'
+
+    def apply(self, fn, context):
+        response.set_header('Cache-control', 'no-store')
 
 
 class HTTPRobotServer(AbstractServer):
@@ -69,8 +78,9 @@ class HTTPRobotServer(AbstractServer):
 
         jd = lambda s: json.dumps(s, cls=MyJSONEncoder)
         self.app.install(bottle.JSONPlugin(json_dumps=jd))
+        self.app.install(CacheBuster())
 
-        if(cross_domain_origin):
+        if (cross_domain_origin):
             self.app.install(EnableCors(cross_domain_origin))
 
         rr = self.restfull_robot
@@ -242,4 +252,4 @@ class HTTPRobotServer(AbstractServer):
                 raise serr
             else:
                 logger.warning("""The webserver port {} is already used.
-The HttpRobotServer is maybe already run or another software use this port.""".format(self.port))
+May be the HttpRobotServer is already running or another software is using this port.""".format(self.port))

--- a/pypot/server/snap.py
+++ b/pypot/server/snap.py
@@ -17,6 +17,7 @@ from ast import literal_eval as make_tuple
 
 from .server import AbstractServer
 from .httpserver import EnableCors
+from .httpserver import CacheBuster
 from ..utils.appdirs import user_data_dir
 
 
@@ -104,6 +105,7 @@ class SnapRobotServer(AbstractServer):
         self.quiet = quiet
         self.app = bottle.Bottle()
         self.app.install(EnableCors())
+        self.app.install(CacheBuster())
 
         rr = self.restfull_robot
 
@@ -168,7 +170,7 @@ class SnapRobotServer(AbstractServer):
         @self.app.get('/motors/set/registers/<motors_register_value>')
         def set_motors_registers(motors_register_value):
             """ Allow lot of motors register settings with a single http request
-                Be carefull: with lot of motors, it could overlap the GET max
+                Be careful: with lot of motors, it could overlap the GET max
                     lentgh of your web browser
                 """
             for m_settings in motors_register_value.split(';'):

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,3 @@
 ignore = E501,E731
 max-line-length = 160
 exclude = build,dist,*.egg-info,doc/*,tests/*,*remoteApiBindings/vrepConst.py,*remoteApiBindings/vrep.py,__init__.py,*samples/benchmarks/*,*utils/appdirs.py
-


### PR DESCRIPTION
Also remove some extra typos.

This is meant to prevent the IE infinite cache policy that bothers some of our users (see [this thread](https://forum.poppy-project.org/t/premiers-pas-suite-avec-snap/2899)).

I also followed some Bottle best practices for setting headers and edited the CORS plugin.