### PR TITLE
Update conversion.py - PID handling

### DIFF
--- a/pypot/dynamixel/conversion.py
+++ b/pypot/dynamixel/conversion.py
@@ -123,15 +123,15 @@ def dxl_to_load(value, model):
 
 
 def dxl_to_pid(value, model):
-    return (value[0] * 0.004,
+    return (value[2] * 0.004,
             value[1] * 0.48828125,
-            value[2] * 0.125)
+            value[0] * 0.125)
 
 
 def pid_to_dxl(value, model):
     def truncate(x):
         return int(max(0, min(x, 254)))
-    return [truncate(x * y) for x, y in zip(value, (250, 2.048, 8.0))]
+    return [truncate(x * y) for x, y in zip(value, (250, 2.048, 8.0))].reverse()
 
 # MARK: - Model
 


### PR DESCRIPTION
Changed dxl_to_pid and pid_to_dxl to handle the [P, I, D] values correctly - since the internal representation in the DXL servos is DIP.