### PR TITLE
Update server.py

### DIFF
--- a/pypot/server/server.py
+++ b/pypot/server/server.py
@@ -9,15 +9,15 @@ class AbstractServer(object):
     def run(self):
         raise NotImplementedError
 
-
-try:
-    import zerorpc
-
-    class RemoteRobotServer(AbstractServer):
-        def run(self):
+        
+class RemoteRobotServer(AbstractServer):
+    def run(self):
+        try: 
+            import zerorpc
             server = zerorpc.Server(self.restful_robot)
             server.bind('tcp://{}:{}'.format(self.host, self.port))
             server.run()
-
-except ImportError:
-    pass
+        except ImportError:
+            print (("Warning: The Python module 'zerorpc' is not installed. "
+                    "Therefore the feature RemoteRobotServer is disabled. "
+                    "On most systems this module can be installed with the command 'pip install zerorpc'."))

--- a/pypot/server/server.py
+++ b/pypot/server/server.py
@@ -1,5 +1,9 @@
 from .rest import RESTRobot
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class AbstractServer(object):
     def __init__(self, robot, host, port):
@@ -18,6 +22,6 @@ class RemoteRobotServer(AbstractServer):
             server.bind('tcp://{}:{}'.format(self.host, self.port))
             server.run()
         except ImportError:
-            print (("Warning: The Python module 'zerorpc' is not installed. "
-                    "Therefore the feature RemoteRobotServer is disabled. "
-                    "On most systems this module can be installed with the command 'pip install zerorpc'."))
+            logger.warning(("Warning: The Python module 'zerorpc' is not installed. "
+                            "Therefore the feature RemoteRobotServer is disabled. "
+                            "On most systems this module can be installed with the command 'pip install zerorpc'."))


### PR DESCRIPTION
better exception handling than "pass".

The RemoteRobotServer just fails silently if the module 'zerorpc' is not installed. This PR adds a proper warning if the python pkg isn't installed and the class is required.