### PR TITLE
Welcome new vrep users

### DIFF
--- a/pypot/vrep/__init__.py
+++ b/pypot/vrep/__init__.py
@@ -4,8 +4,7 @@ import logging
 from functools import partial
 from collections import OrderedDict
 
-from .io import (VrepIO, close_all_connections,
-                 VrepIOError, VrepConnectionError)
+from .io import (VrepIO, close_all_connections, VrepConnectionError)
 
 from .controller import VrepController, VrepObjectTracker
 from .controller import VrepCollisionTracker, VrepCollisionDetector
@@ -94,8 +93,6 @@ def from_vrep(config, vrep_host='127.0.0.1', vrep_port=19997, scene=None,
               for name in config['motors'].keys()]
 
     vc = VrepController(vrep_io, scene, motors)
-    vc._init_vrep_streaming()
-
     sensor_controllers = []
 
     if tracked_objects:

--- a/pypot/vrep/io.py
+++ b/pypot/vrep/io.py
@@ -1,6 +1,7 @@
 import os
 import time
 import ctypes
+import warnings
 
 from threading import Lock
 
@@ -106,6 +107,13 @@ class VrepIO(AbstractIO):
 
         if start:
             self.start_simulation()
+            time.sleep(1)
+            # testing if the vrep pop-up for new vrep user has raised
+            t = remote_api.simxGetPingTime(self.client_id)
+            if t[1] > 4000:
+                warnings.warn('Communication with Vrep blocked. If a Vrep Pop-up has raised '
+                              'close it now !')
+                time.sleep(5)
 
     def start_simulation(self):
         """ Starts the simulation.
@@ -317,7 +325,7 @@ class VrepIO(AbstractIO):
 
             err = [bool((err >> i) & 1) for i in range(len(vrep_error))]
 
-            if remote_api.simx_return_novalue_flag not in err:
+            if True not in err:
                 break
 
             time.sleep(VrepIO.TIMEOUT)
@@ -375,16 +383,6 @@ def close_all_connections():
 
 
 # V-REP Errors
-class VrepIOError(Exception):
-
-    """ Base class for V-REP IO Errors. """
-
-    def __init__(self, error_code, message):
-        message = 'V-REP error code {} ({}): "{}"'.format(
-            error_code, vrep_error[error_code], message)
-        Exception.__init__(self, message)
-
-
 class VrepIOErrors(Exception):
     pass
 


### PR DESCRIPTION
One of the reccurent problem for new user with robot simulation is the vrep window blocking the communication.  Sure some newbies just give up to use pypot because they just think : "Another open source project that doesn't work..." Moreover the error raised put the new user in a deadlock and they have to kill the python kernel 3 times before to use normaly the software.

And as you know only motivated people go through the documentation and the first impression is important.
So I propose a way to detect this boring window at startup and to print a warning.

Some other few things I changed in the code  : 
Replace a strange way to use True, duplicate use for _init_vrep_streaming and dead code removing.