### PR TITLE
make moving_speed oriented

### DIFF
--- a/pypot/dynamixel/motor.py
+++ b/pypot/dynamixel/motor.py
@@ -106,7 +106,7 @@ class DxlMotor(Motor):
     present_position = DxlPositionRegister()
     goal_position = DxlPositionRegister(rw=True)
     present_speed = DxlOrientedRegister()
-    moving_speed = DxlRegister(rw=True)
+    moving_speed = DxlOrientedRegister(rw=True)
     present_load = DxlOrientedRegister()
     torque_limit = DxlRegister(rw=True)
 
@@ -342,6 +342,7 @@ class DxlXL320Motor(DxlMXMotor):
     registers = list(DxlMXMotor.registers)
 
     led = DxlRegister(rw=True)
+    control_mode = DxlRegister(rw=True)
 
     """ This class represents the XL-320 robotis motor. """
     def __init__(self, id, name=None, model='XL-320',


### PR DESCRIPTION
To use wheel mode it is interesting to have the possibility to change the rotation of the wheel and to use the direct attribute for that. It is why it could be better to make moving_speed an oriented registered.
Tested with xl-320 I don't really know what level is the best to make the change so I made it at DXLMotor but I don't know if other motors have a wheel mode...