### PR TITLE
autodetect_robot dedicates port to first controller with attached servos

### DIFF
--- a/pypot/dynamixel/__init__.py
+++ b/pypot/dynamixel/__init__.py
@@ -134,5 +134,6 @@ def autodetect_robot():
 
             c = BaseDxlController(dxl_io, motors)
             motor_controllers.append(c)
+            break
 
     return Robot(motor_controllers)


### PR DESCRIPTION
Port is dedicated to first controller with detected servos.

Without this change, get: "pypot.dynamixel.io.abstract_io.DxlError: Another instance of pypot use the port /dev/tty.usbmodem1421" when protocol v1 motors are detected.