### PR TITLE
Fix poppy-simu and allow simple dummy robot use

### DIFF
--- a/pypot/creatures/abstractcreature.py
+++ b/pypot/creatures/abstractcreature.py
@@ -41,7 +41,7 @@ class AbstractPoppyCreature(Robot):
 
         :param str config: path to a specific json config (if None uses the default config of the poppy creature - e.g. poppy_humanoid.json)
 
-        :param str simulator: name of the simulator used : 'vrep' or 'poppy-simu'
+        :param str simulator: name of the simulator used : 'vrep', 'poppy-simu', or 'dummy-robot'
         :param str scene: specify a particular simulation scene (if None uses the default scene of the poppy creature, use "keep-existing" to keep the current VRep scene - e.g. poppy_humanoid.ttt)
         :param str host: host of the simulator
         :param int port: port of the simulator

--- a/pypot/creatures/abstractcreature.py
+++ b/pypot/creatures/abstractcreature.py
@@ -101,6 +101,9 @@ class AbstractPoppyCreature(Robot):
                     raise IOError('Connection to V-REP failed!')
 
             elif simulator == 'poppy-simu':
+                use_http = True
+                poppy_creature = use_dummy_robot(config)
+            elif simulator == 'dummy':
                 poppy_creature = use_dummy_robot(config)
             else:
                 raise ValueError('Unknown simulation mode: "{}"'.format(simulator))

--- a/pypot/creatures/services_launcher.py
+++ b/pypot/creatures/services_launcher.py
@@ -82,13 +82,13 @@ Examples:
                         action='store', nargs='?',
                         choices=installed_poppy_creatures.keys())
     parser.add_argument('--dummy',
-                        help='use a dummy robot',
+                        help='use a simulated dummy robot',
                         action='store_true')
     parser.add_argument('--vrep',
                         help='use a V-REP simulated Poppy Creature',
                         action='store_true')
     parser.add_argument('--poppy-simu',
-                        help='use a Three.js visualization',
+                        help='start a simulated dummy robot and the HTTP API to connect to the viewer on simu.poppy-project.org',
                         action='store_true')
     parser.add_argument('--snap',
                         help='start a Snap! robot server',

--- a/pypot/creatures/services_launcher.py
+++ b/pypot/creatures/services_launcher.py
@@ -58,6 +58,8 @@ def poppy_params_from_args(args):
         params['simulator'] = 'vrep'
     elif args.poppy_simu:
         params['simulator'] = 'poppy-simu'
+    elif args.dummy:
+        params['simulator'] = 'dummy'
 
     if args.disable_camera:
         params['camera'] = 'dummy'
@@ -79,6 +81,9 @@ Examples:
                         help='poppy creature name',
                         action='store', nargs='?',
                         choices=installed_poppy_creatures.keys())
+    parser.add_argument('--dummy',
+                        help='use a dummy robot',
+                        action='store_true')
     parser.add_argument('--vrep',
                         help='use a V-REP simulated Poppy Creature',
                         action='store_true')
@@ -167,7 +172,7 @@ Examples:
         ch.setFormatter(formatter)
         logging.getLogger('').addHandler(ch)
 
-    if not any([args.snap, args.http, args.remote, args.poppy_simu, args.ws]):
+    if not any([args.snap, args.http, args.remote, args.poppy_simu, args.ws, args.dummy]):
         print('No service specified! See --help for details.')
         sys.exit(1)
 

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -17,7 +17,7 @@ class EmptyPrim(LoopPrimitive):
 
 class TestDummy(unittest.TestCase):
     def setUp(self):
-        self.jr = PoppyErgoJr(simulator='poppy-simu')
+        self.jr = PoppyErgoJr(simulator='dummy')
 
     def test_dummy_controller(self):
         for m in self.jr.motors:


### PR DESCRIPTION
People were used to poppy-simu bringing up the http server, which
is no longer the case since commit 0a68a21. This has been restored
as it was prior to this commit.
However, using a simulated robot without the need of the http server is
relevant, and this option is now available through the `simulator`
parameter. `poppy-services` was also modified to reflect this new
option.

To use dummy robot in Python code:

```
from pypot.creatures import PoppyErgoJr
robot = PoppyErgoJr(simulator='dummy')
```

Using `poppy-services` command line utility:

```
poppy-services --dummy poppy-ergo-jr
```