### PR TITLE
Adding proper speed conversion for MX-12

### DIFF
--- a/pypot/dynamixel/conversion.py
+++ b/pypot/dynamixel/conversion.py
@@ -38,7 +38,7 @@ torque_max = {  # in N.m
     'RX-64': 4.,
     'XL-320': 0.39,
     'SR-RH4D': 0.57,
-    'EX-106': 10.9
+    'EX-106': 10.9,
 }
 
 velocity = {  # in degree/s
@@ -85,23 +85,26 @@ def degree_to_dxl(value, model):
 
 # MARK: - Speed
 
+# Speed factor (RPM per least significant bit)
+def _speed_factor(model):
+    if model == 'MX-12':
+        return 0.916
+
+    if model.startswith('MX') or model.startswith('SR'):
+        return 0.114
+
+    return 0.111
 
 def dxl_to_speed(value, model):
     cw, speed = divmod(value, 1024)
     direction = (-2 * cw + 1)
 
-    speed_factor = 0.111
-    if model.startswith('MX') or model.startswith('SR'):
-        speed_factor = 0.114
-
-    return direction * (speed * speed_factor) * 6
+    return direction * (speed * _speed_factor(model)) * 6
 
 
 def speed_to_dxl(value, model):
     direction = 1024 if value < 0 else 0
-    speed_factor = 0.111
-    if model.startswith('MX') or model.startswith('SR'):
-        speed_factor = 0.114
+    speed_factor = _speed_factor(model)
 
     max_value = 1023 * speed_factor * 6
     value = min(max(value, -max_value), max_value)

--- a/pypot/dynamixel/conversion.py
+++ b/pypot/dynamixel/conversion.py
@@ -38,7 +38,7 @@ torque_max = {  # in N.m
     'RX-64': 4.,
     'XL-320': 0.39,
     'SR-RH4D': 0.57,
-    'EX-106': 10.9,
+    'EX-106': 10.9
 }
 
 velocity = {  # in degree/s


### PR DESCRIPTION
This is adding proper speed conversion for MX-12W, which is 0.916 rpm:
https://emanual.robotis.com/docs/en/dxl/mx/mx-12w/#moving-speed

I also factored out the speed ratio in a method to avoid duplication

This was tested on an MX-12W:  `set_moving_speed` is now properly giving degrees/s as expected