### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/logging.rst
+++ b/doc/logging.rst
@@ -19,7 +19,7 @@ Pypot is logging information at all different levels:
 
 Pypot's logging naming convention is following pypot's architecture. Here is the detail of what pypot is logging with the associated logger's name:
 
-* The logger's name **pypot.dynamixel.io** is logging information related to opening/closing port (INFO) and each sent/received package (DEBUG). The communication and timeout error are also logged (WARNING). This logger always provides you the port name, the baudrate and timout of your connection as extra information.
+* The logger's name **pypot.dynamixel.io** is logging information related to opening/closing port (INFO) and each sent/received package (DEBUG). The communication and timeout error are also logged (WARNING). This logger always provides you the port name, the baudrate and timeout of your connection as extra information.
 
 * The logger **pypot.dynamixel.motor** is logging each time a register of a motor is set (DEBUG). The name of the register, the name of the motor and the set value are given in the message.
 

--- a/pypot/dynamixel/io/abstract_io.py
+++ b/pypot/dynamixel/io/abstract_io.py
@@ -50,7 +50,7 @@ class AbstractDxlIO(object):
                  use_sync_read=False,
                  error_handler_cls=None,
                  convert=True):
-        """ At instanciation, it opens the serial port and sets the communication parameters.
+        """ At instantiation, it opens the serial port and sets the communication parameters.
 
             :param string port: the serial port to use (e.g. Unix (/dev/tty...), Windows (COM...)).
             :param int baudrate: default for new motors: 57600, for PyPot motors: 1000000

--- a/pypot/dynamixel/motor.py
+++ b/pypot/dynamixel/motor.py
@@ -167,7 +167,7 @@ class DxlMotor(Motor, metaclass=RegisterOwner):
 
         else:
             # 0.7 corresponds approx. to the min speed that will be converted into 0
-            # and as 0 corredsponds to setting the max speed, we have to check this case
+            # and as 0 corresponds to setting the max speed, we have to check this case
             value = numpy.sign(value) * 0.7 if abs(value) < 0.7 else value
 
             self.goal_position = numpy.sign(value) * self.max_pos

--- a/pypot/dynamixel/protocol/v1.py
+++ b/pypot/dynamixel/protocol/v1.py
@@ -119,7 +119,7 @@ class DxlSyncReadPacket(DxlInstructionPacket):
 
 
 class DxlWriteDataPacket(DxlInstructionPacket):
-    """ This class is used to reprensent write data packet (to write value). """
+    """ This class is used to represent write data packet (to write value). """
     def __new__(cls, id, address, coded_value):
         return DxlInstructionPacket.__new__(cls, id,
                                             DxlInstruction.WRITE_DATA,

--- a/pypot/dynamixel/protocol/v2.py
+++ b/pypot/dynamixel/protocol/v2.py
@@ -124,7 +124,7 @@ class DxlSyncReadPacket(DxlInstructionPacket):
 
 
 class DxlWriteDataPacket(DxlInstructionPacket):
-    """ This class is used to reprensent write data packet (to write value). """
+    """ This class is used to represent write data packet (to write value). """
     def __new__(cls, id, address, coded_value):
         return DxlInstructionPacket.__new__(cls, id,
                                             DxlInstruction.WRITE_DATA,

--- a/pypot/primitive/primitive.py
+++ b/pypot/primitive/primitive.py
@@ -43,7 +43,7 @@ class Primitive(StoppableThread):
     properties = []
 
     def __init__(self, robot):
-        """ At instanciation, it automatically transforms the :class:`~pypot.robot.robot.Robot` into a :class:`~pypot.primitive.primitive.MockupRobot`.
+        """ At instantiation, it automatically transforms the :class:`~pypot.robot.robot.Robot` into a :class:`~pypot.primitive.primitive.MockupRobot`.
 
         .. warning:: You should not directly pass motors as argument to the primitive. If you need to, use the method :meth:`~pypot.primitive.primitive.Primitive.get_mockup_motor` to transform them into "fake" motors. See the :ref:`write_own_prim` section for details.
 
@@ -294,7 +294,7 @@ class MockupMotor(object):
 
         else:
             # 0.7 corresponds approx. to the min speed that will be converted into 0
-            # and as 0 corredsponds to setting the max speed, we have to check this case
+            # and as 0 corresponds to setting the max speed, we have to check this case
             value = numpy.sign(value) * 0.7 if abs(value) < 0.7 else value
 
             self.goal_position = numpy.sign(value) * self.max_pos

--- a/pypot/sensor/arduino/arduino_sensor.py
+++ b/pypot/sensor/arduino/arduino_sensor.py
@@ -6,7 +6,7 @@ from ...utils import StoppableLoopThread
 
 
 class ArduinoSensor(Sensor):
-    """ Give acces to arduino sensor.
+    """ Give access to arduino sensor.
 
         Here it is an example of the arduino code to retrieve the time:
 

--- a/pypot/sensor/depth/sonar.py
+++ b/pypot/sensor/depth/sonar.py
@@ -11,7 +11,7 @@ from ...utils.i2c_controller import I2cController
 
 
 class SonarSensor(Sensor):
-    """ Give acces to ultrasonic I2C modules SRF-02 in a *pypot way*
+    """ Give access to ultrasonic I2C modules SRF-02 in a *pypot way*
 
         It provides one register: distance (in meters).
 
@@ -45,7 +45,7 @@ class SonarSensor(Sensor):
 
 
 class Sonar(object):
-    """ Give acces to ultrasonic I2C modules SRF-02 connected with I2C pin of your board.
+    """ Give access to ultrasonic I2C modules SRF-02 connected with I2C pin of your board.
         To get more information, go to http://www.robot-electronics.co.uk/htm/srf02techI2C.htm
 
         Example:

--- a/pypot/vrep/io.py
+++ b/pypot/vrep/io.py
@@ -267,7 +267,7 @@ class VrepIO(AbstractIO):
         self._inject_lua_code(lua_code)
 
     def _inject_lua_code(self, lua_code):
-        """ Sends raw lua code and evaluate it wihtout any checking! """
+        """ Sends raw lua code and evaluate it without any checking! """
         msg = (ctypes.c_ubyte * len(lua_code)).from_buffer_copy(lua_code.encode())
         self.call_remote_api('simxWriteStringStream', 'my_lua_code', msg)
 

--- a/pypot/vrep/remoteApiBindings/vrepConst.py
+++ b/pypot/vrep/remoteApiBindings/vrepConst.py
@@ -172,7 +172,7 @@ sim_message_eventcallback_abouttoundo                 =0x118   # the undo button
 sim_message_eventcallback_undoperformed                 =0x119   # the undo button was hit and a previous state restored 
 sim_message_eventcallback_abouttoredo                 =0x11a   # the redo button was hit and a future state is about to be restored  
 sim_message_eventcallback_redoperformed                 =0x11b   # the redo button was hit and a future state restored  
-sim_message_eventcallback_scripticondblclick         =0x11c   # scipt icon was double clicked.  (aux[0]=object handle associated with script set replyData[0] to 1 if script should not be opened)  
+sim_message_eventcallback_scripticondblclick         =0x11c   # script icon was double clicked.  (aux[0]=object handle associated with script set replyData[0] to 1 if script should not be opened)  
 sim_message_eventcallback_simulationabouttostart     =0x11d
 sim_message_eventcallback_simulationended            =0x11e
 sim_message_eventcallback_reserved5                     =0x11f   # do not use 
@@ -198,8 +198,8 @@ sim_objectproperty_reserved1                =0x0000
 sim_objectproperty_reserved2                =0x0001
 sim_objectproperty_reserved3                =0x0002
 sim_objectproperty_reserved4                =0x0003
-sim_objectproperty_reserved5                =0x0004 # formely sim_objectproperty_visible 
-sim_objectproperty_reserved6                =0x0008 # formely sim_objectproperty_wireframe 
+sim_objectproperty_reserved5                =0x0004 # formerly sim_objectproperty_visible 
+sim_objectproperty_reserved6                =0x0008 # formerly sim_objectproperty_wireframe 
 sim_objectproperty_collapsed                =0x0010
 sim_objectproperty_selectable                =0x0020
 sim_objectproperty_reserved7                =0x0040

--- a/samples/notebooks/readme.md
+++ b/samples/notebooks/readme.md
@@ -11,7 +11,7 @@ We already have written a few tutorial notebooks that you can browse here: https
 
 Other notebooks should shorty extend this list!
 
-In the next sections, we decribe how those notebooks can be [viewed](https://github.com/poppy-project/pypot/blob/master/samples/notebooks/readme.md#browse-notebook-online), [installed](https://github.com/poppy-project/pypot/blob/master/samples/notebooks/readme.md#running-notebooks-locally), [run on your robot](https://github.com/poppy-project/pypot/blob/master/samples/notebooks/readme.md#connecting-to-a-remote-notebook) or [locally](https://github.com/poppy-project/pypot/blob/master/samples/notebooks/readme.md#running-notebooks-locally), shared and how you can [contribute](https://github.com/poppy-project/pypot/blob/master/samples/notebooks/readme.md#contribute) by writting your own notebooks!
+In the next sections, we decribe how those notebooks can be [viewed](https://github.com/poppy-project/pypot/blob/master/samples/notebooks/readme.md#browse-notebook-online), [installed](https://github.com/poppy-project/pypot/blob/master/samples/notebooks/readme.md#running-notebooks-locally), [run on your robot](https://github.com/poppy-project/pypot/blob/master/samples/notebooks/readme.md#connecting-to-a-remote-notebook) or [locally](https://github.com/poppy-project/pypot/blob/master/samples/notebooks/readme.md#running-notebooks-locally), shared and how you can [contribute](https://github.com/poppy-project/pypot/blob/master/samples/notebooks/readme.md#contribute) by writing your own notebooks!
 
 # Open Source
 All the resources content from the Poppy Project is open source. This naturally also extends to the notebooks.


### PR DESCRIPTION
There are small typos in:
- doc/logging.rst
- pypot/dynamixel/io/abstract_io.py
- pypot/dynamixel/motor.py
- pypot/dynamixel/protocol/v1.py
- pypot/dynamixel/protocol/v2.py
- pypot/primitive/primitive.py
- pypot/sensor/arduino/arduino_sensor.py
- pypot/sensor/depth/sonar.py
- pypot/vrep/io.py
- pypot/vrep/remoteApiBindings/vrepConst.py
- samples/notebooks/readme.md

Fixes:
- Should read `access` rather than `acces`.
- Should read `represent` rather than `reprensent`.
- Should read `instantiation` rather than `instanciation`.
- Should read `formerly` rather than `formely`.
- Should read `corresponds` rather than `corredsponds`.
- Should read `writing` rather than `writting`.
- Should read `without` rather than `wihtout`.
- Should read `timeout` rather than `timout`.
- Should read `script` rather than `scipt`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md